### PR TITLE
主页测试视图合并

### DIFF
--- a/SYSTools/Helpers/LocalizationManager.cs
+++ b/SYSTools/Helpers/LocalizationManager.cs
@@ -22,6 +22,8 @@ namespace SYSTools.Helpers
                 if (_currentCulture != value)
                 {
                     _currentCulture = value;
+                    // 传递属性名以便订阅者识别变化，同时兼容空字符串（触发所有绑定更新）
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentCulture)));
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(string.Empty));
                 }
             }

--- a/SYSTools/MainWindow.xaml
+++ b/SYSTools/MainWindow.xaml
@@ -18,7 +18,7 @@
         Loaded="Window_Loaded"
         Closed="Window_Closed"
         Deactivated="Window_Deactivated"
-        Height="670" Width="1100" MinWidth="1100" MinHeight="670" >
+        Height="700" Width="1100" MinWidth="1100" MinHeight="700" >
 
     <Grid>
         <!--设定为预设无背景图片-->

--- a/SYSTools/Pages/Home.xaml
+++ b/SYSTools/Pages/Home.xaml
@@ -9,38 +9,61 @@
       mc:Ignorable="d" 
       d:DesignHeight="610" d:DesignWidth="1040"
       KeepAlive="True"
-      Title="Home" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" MinWidth="1040" MinHeight="610" Loaded="Page_Loaded">
+      Title="Home" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" MinWidth="1040" MinHeight="610" 
+      Loaded="Page_Loaded" Unloaded="Page_Unloaded">
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="18*"/>
-            <ColumnDefinition Width="47*"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="100"/>
-            <RowDefinition Height="129*"/>
-            <RowDefinition Height="76*"/>
-            <RowDefinition Height="100"/>
-        </Grid.RowDefinitions>
-        <Image x:Name="image" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Column="1" Grid.Row="3" Source="/SYSTools;component/Resources/LOGO.png" Opacity="0.5" Width="160" Height="90"/>
-        
-        <Border  BorderThickness="1" CornerRadius="5" Grid.RowSpan="4" Grid.ColumnSpan="2"/>
-        
-        <StackPanel x:Name="Home_SP_Tip" HorizontalAlignment="Center" VerticalAlignment="Center" Orientation="Horizontal" Grid.ColumnSpan="2">
-            <muxc:FontIcon FontFamily="{DynamicResource SegoeIcons}" Glyph="&#xF1AD;" HorizontalAlignment="Center" VerticalAlignment="Center" Width="70" Height="70" FontSize="45" Margin="15,0,0,0"  />
-            <TextBlock VerticalAlignment="Center" Text="{model:Resource Key=Welcome}" FontSize="30 " HorizontalAlignment="Center"  d:IsLocked="True" />
-        </StackPanel>
-        <Border BorderThickness="1" Margin="10" Grid.Row="3" CornerRadius="5" Padding="25,0,0,0" Grid.ColumnSpan="2" BorderBrush="#CC202020" >
-            <StackPanel Margin="0" Orientation="Horizontal">
-                <muxc:FontIcon FontFamily="{DynamicResource SegoeIcons}" Glyph="&#xE141;" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="25"   />
-                <TextBlock VerticalAlignment="Center" Text="{model:Resource Key=News}" FontSize="20" HorizontalAlignment="Center"  d:IsLocked="True" Margin="10,0,0,0"/>
-                <TextBlock x:Name="PublicNews" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{model:Resource Key=LoadingNews}" FontSize="20" Margin="20,0,0,0">
+        <!-- 背景Logo -->
+        <Image x:Name="image" HorizontalAlignment="Right" VerticalAlignment="Bottom" 
+               Source="/SYSTools;component/Resources/LOGO.png" Opacity="0.5" Height="90" Width="160"/>
+        <Border BorderThickness="1" CornerRadius="5"/>
+        <!-- 主滚动区域 -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Margin="15,15,15,100">
+                <!-- 欢迎区域 -->
+                <Border Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1" CornerRadius="8" Padding="20,15" Margin="0,0,0,12">
+                    <Border.Effect>
+                        <DropShadowEffect Color="Black" Direction="270" ShadowDepth="2" BlurRadius="6" Opacity="0.15"/>
+                    </Border.Effect>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock Text="&#xF1AD;" FontFamily="{DynamicResource SegoeIcons}" 
+                                   FontSize="40" VerticalAlignment="Center" Margin="0,0,15,0"
+                                   Foreground="{DynamicResource AccentTextFillColorPrimaryBrush}"/>
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock x:Name="WelcomeText" Text="{model:Resource Key=Welcome}" 
+                                       FontSize="28" FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                            <TextBlock x:Name="UsernameText" Text="" FontSize="14" Margin="0,2,0,0"
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+                <!-- 卡片网格容器 -->
+                <Grid x:Name="CardsPanel" HorizontalAlignment="Stretch"/>
+            </StackPanel>
+        </ScrollViewer>
+        <!-- 底部公告栏 -->
+        <Border VerticalAlignment="Bottom" Height="80" Margin="10"
+                Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1" CornerRadius="8" Padding="20,0">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <TextBlock Text="&#xE141;" FontFamily="{DynamicResource SegoeIcons}" 
+                           FontSize="24" VerticalAlignment="Center" Margin="0,0,15,0"
+                           Foreground="{DynamicResource AccentTextFillColorSecondaryBrush}"/>
+                <TextBlock Text="{model:Resource Key=News}" FontSize="16" FontWeight="SemiBold"
+                           VerticalAlignment="Center" Margin="0,0,15,0"
+                           Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                <TextBlock x:Name="PublicNews" Text="{model:Resource Key=LoadingNews}" 
+                           FontSize="15" VerticalAlignment="Center" TextWrapping="Wrap"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}">
                     <TextBlock.Triggers>
                         <EventTrigger RoutedEvent="TextBlock.Loaded">
                             <BeginStoryboard>
                                 <Storyboard>
-                                    <DoubleAnimation
-                                        Storyboard.TargetProperty="Opacity"
-                                        From="0.0" To="1.0" Duration="0:0:0.5"/>
+                                    <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                   From="0.0" To="1.0" Duration="0:0:0.5"/>
                                 </Storyboard>
                             </BeginStoryboard>
                         </EventTrigger>
@@ -48,54 +71,5 @@
                 </TextBlock>
             </StackPanel>
         </Border>
-
-        <Border BorderThickness="1" Margin="10,10,10,0" Grid.Row="1" CornerRadius="5" Grid.RowSpan="2" BorderBrush="#CC202020"/>
-
-        <StackPanel Grid.Row="1" Orientation="Horizontal" VerticalAlignment="Top" Margin="0,30,0,0" HorizontalAlignment="Center">
-            <muxc:FontIcon FontFamily="{DynamicResource SegoeIcons}" Glyph="&#xE2AD;" Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,0,10,0"  />
-
-            <TextBlock TextWrapping="Wrap" 
-                       Text="{model:Resource Key=SystemTime}" 
-                       Grid.Row="1" FontSize="18" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-        </StackPanel>
-
-        <StackPanel Grid.Row="1" Margin="20,75,20,10">
-            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" 
-                   Text="{model:Resource Key=SystemStartTime}" 
-                   VerticalAlignment="Center" 
-                   Grid.Row="1" FontSize="20" Margin="0,0,0,10"/>
-
-            <TextBlock x:Name="OpenTime" HorizontalAlignment="Center" TextWrapping="Wrap" Text="" VerticalAlignment="Center" Grid.Row="1" FontSize="20"/>
-
-            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap" 
-                   Text="{model:Resource Key=SystemRunTime}" 
-                   VerticalAlignment="Center" 
-                   Grid.Row="1" FontSize="20" Margin="0,10,0,10"/>
-
-            <TextBlock x:Name="RunTime" HorizontalAlignment="Center" TextWrapping="Wrap" Text="" VerticalAlignment="Center" Grid.Row="1" FontSize="20" Margin="0,0,0,10"/>
-
-        </StackPanel>
-        
-        
-        <TextBlock Text="{model:Resource Key=CurrentSystem}" 
-                   VerticalAlignment="Top" Grid.Row="2" FontSize="18" 
-                   TextWrapping="Wrap" HorizontalAlignment="Center"/>
-        
-        <TextBlock x:Name="Windows_Name" Text="" VerticalAlignment="Top" Grid.Row="2" TextWrapping="Wrap" HorizontalAlignment="Center" Margin="0,40,0,0" Visibility="Visible" TextTrimming="None" FontStretch="Normal" MaxWidth="230" Block.TextAlignment="Center" FontSize="16"/>
-        
-        <TextBlock x:Name="Windows_Version" Text="" VerticalAlignment="Top" Grid.Row="2" FontSize="16" TextWrapping="Wrap" HorizontalAlignment="Center" Margin="0,90,0,0"/>
-
-        <Border BorderThickness="1" Grid.Column="1" Margin="0,10,10,0" Grid.Row="1" CornerRadius="5" BorderBrush="#CC202020" />
-
-        <TextBlock x:Name="IP" TextWrapping="Wrap" Text="{model:Resource Key=IP}" HorizontalAlignment="Center" VerticalAlignment="Top" FontSize="20" Margin="0,20,0,0" Grid.Column="1" Grid.Row="1" />
-        <TextBlock x:Name="IPv4" Text="***.***.***.***" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20" Margin="0,-40,0,0" Grid.Column="1" Grid.Row="1" MouseLeftButtonDown="IPv4_MouseLeftButtonDown" MouseRightButtonDown="IPv4_MouseRightButtonDown" ToolTip="{model:Resource Key=LR_ToolTip}"/>
-        <TextBlock x:Name="IPv6" Text="****:****:****:****:****:****:****:****" TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20" Margin="0,0,0,-100" Grid.Column="1" Grid.Row="1" MouseLeftButtonDown="IPv6_MouseLeftButtonDown" MouseRightButtonDown="IPv6_MouseRightButtonDown" ToolTip="{model:Resource Key=LR_ToolTip}"/>
-        <TextBlock x:Name="Provider" TextWrapping="Wrap" Text="{model:Resource Key=ServiceProvider}" HorizontalAlignment="Right" VerticalAlignment="Bottom" FontSize="10" Grid.Column="1" Grid.Row="1" Margin="0,0,15,5"/>
-
-
-        <Border BorderThickness="1" Grid.Column="1" Margin="0,10,10,0" Grid.Row="2" CornerRadius="5" BorderBrush="#CC202020" />
-        
-        <TextBlock TextWrapping="Wrap" Grid.Column="1" Grid.Row="2" Text="一言卡片(Hitokoto Card)" HorizontalAlignment="Center" VerticalAlignment="Top" FontSize="15" Margin="0,25,0,0" />
-        <TextBlock x:Name="Hitokoto" Block.TextAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="15" TextWrapping="Wrap" Text="Now loading" Grid.Column="1" Grid.Row="2" Margin="0,0,0,-15" />
     </Grid>
-</Page> 
+</Page>

--- a/SYSTools/Pages/Home.xaml.cs
+++ b/SYSTools/Pages/Home.xaml.cs
@@ -9,7 +9,11 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using System.Linq;
 using System.Collections.Generic;
+using System.Windows.Media;
 using System.Windows.Media.Animation;
+using System.Threading.Tasks;
+using System.Windows.Media.Effects;
+using System.Windows.Controls.Primitives;
 
 namespace SYSTools.Pages
 {
@@ -18,106 +22,895 @@ namespace SYSTools.Pages
     /// </summary>
     public partial class Home : Page
     {
-        static readonly HttpClient client = new HttpClient();
+        static readonly HttpClient client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
         DateTime UPTime = DateTime.Now.AddMilliseconds(-(Environment.TickCount));
         private List<string> notices = new List<string>();
         private int currentNoticeIndex = 0;
         private DispatcherTimer noticeTimer;
-        private DispatcherTimer mainTimer; // 将计时器作为类成员
+        private DispatcherTimer mainTimer;
+        private DispatcherTimer resourceTimer; // 资源监控定时器
         
-        // 缓存本地化字符串和语言判断结果
-        private string dayUnit;
-        private string hourUnit; 
-        private string minuteUnit;
-        private string secondUnit;
+        // 缓存本地化字符串
+        private string dayUnit, hourUnit, minuteUnit, secondUnit;
         private bool isChineseLanguage;
+        
+        // 资源监控相关
+        private PerformanceCounter cpuCounter;
+        private PerformanceCounter ramCounter;
+        private TextBlock cpuValueText, memValueText, diskValueText;
+        private Border cpuProgressBar, memProgressBar, diskProgressBar;
 
         public Home()
         {
             InitializeComponent();
             
-            // 初始化主计时器
-            mainTimer = new DispatcherTimer
+            // 初始化性能计数器
+            try
             {
-                Interval = TimeSpan.FromSeconds(1)
-            };
+                cpuCounter = new PerformanceCounter("Processor", "% Processor Time", "_Total");
+                ramCounter = new PerformanceCounter("Memory", "% Committed Bytes In Use");
+                cpuCounter.NextValue(); // 首次调用
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error initializing performance counters: {ex}");
+            }
+            
+            // 初始化主计时器（降低频率到每秒）
+            mainTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
             mainTimer.Tick += Timer_Tick;
             
-            // 初始化公告计时器
-            noticeTimer = new DispatcherTimer
-            {
-                Interval = TimeSpan.FromSeconds(3)
-            };
-            noticeTimer.Tick += NoticeTimer_Tick;
+            // 初始化资源监控定时器（2秒更新一次）
+            resourceTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
+            resourceTimer.Tick += ResourceTimer_Tick;
             
-            // 注册Unloaded事件
-            this.Unloaded += Home_Unloaded;
+            // 初始化公告计时器
+            noticeTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+            noticeTimer.Tick += NoticeTimer_Tick;
         }
 
         private async void Page_Loaded(object sender, RoutedEventArgs e)
         {
-            // 计时器
-            mainTimer?.Stop();
+            // 刷新语言缓存
             RefreshLanguageCache();
+            
+            // 设置用户名
+            UsernameText.Text = Properties.Lang.ResourceManager.GetString("Hello", 
+                System.Globalization.CultureInfo.CurrentUICulture) + " " + Environment.UserName;
+            
+            // 构建卡片布局
+            BuildCardsLayout();
+            
+            // 启动定时器
             UpdateTimeDisplay();
             mainTimer.Start();
+            
+            // 启动资源监控
+            UpdateResourceMonitor();
+            resourceTimer.Start();
+            
+            // 加载一言卡片
+            await LoadHitokotoAsync();
+            
+            // 加载公告
+            await LoadNoticesAsync();
+            
+            // 加载天气
+            await LoadWeatherAsync();
+            
+            // 加载系统健康状态
+            UpdateSystemHealth();
+        }
 
-            isChineseLanguage = System.Globalization.CultureInfo.CurrentUICulture.Name.StartsWith("zh");
+        private void Page_Unloaded(object sender, RoutedEventArgs e)
+        {
+            mainTimer?.Stop();
+            noticeTimer?.Stop();
+            resourceTimer?.Stop();
+            cpuCounter?.Dispose();
+            ramCounter?.Dispose();
+        }
 
-            if (isChineseLanguage)
+        private void BuildCardsLayout()
+        {
+            CardsPanel.Children.Clear();
+            CardsPanel.ColumnDefinitions.Clear();
+            CardsPanel.RowDefinitions.Clear();
+            
+            // 计算列数
+            double availableWidth = this.ActualWidth - 50;
+            if (availableWidth < 400) availableWidth = 1000;
+            int columnCount = Math.Max(2, (int)(availableWidth / 350));
+            
+            // 创建列定义
+            for (int i = 0; i < columnCount; i++)
             {
-                OpenTime.Text = UPTime.ToLongDateString();
+                CardsPanel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
             }
-            else
+            
+            // 创建行定义（3行）
+            for (int i = 0; i < 3; i++)
             {
-                RunTime.Text = UPTime.ToLongDateString();
+                CardsPanel.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
             }
+            
+            int col = 0, row = 0;
+            
+            // 1. 系统时间卡片
+            var timeCard = CreateSystemTimeCard();
+            Grid.SetColumn(timeCard, col++);
+            Grid.SetRow(timeCard, row);
+            CardsPanel.Children.Add(timeCard);
+            
+            // 2. 系统信息卡片
+            if (col >= columnCount) { col = 0; row++; }
+            var sysInfoCard = CreateSystemInfoCard();
+            Grid.SetColumn(sysInfoCard, col++);
+            Grid.SetRow(sysInfoCard, row);
+            CardsPanel.Children.Add(sysInfoCard);
+            
+            // 3. 系统资源卡片
+            if (col >= columnCount) { col = 0; row++; }
+            var resourceCard = CreateResourceMonitorCard();
+            Grid.SetColumn(resourceCard, col++);
+            Grid.SetRow(resourceCard, row);
+            CardsPanel.Children.Add(resourceCard);
+            
+            // 4. 系统健康卡片
+            if (col >= columnCount) { col = 0; row++; }
+            var healthCard = CreateSystemHealthCard();
+            Grid.SetColumn(healthCard, col++);
+            Grid.SetRow(healthCard, row);
+            CardsPanel.Children.Add(healthCard);
+            
+            // 5. 快速操作卡片
+            if (col >= columnCount) { col = 0; row++; }
+            var quickActionsCard = CreateQuickActionsCard();
+            Grid.SetColumn(quickActionsCard, col++);
+            Grid.SetRow(quickActionsCard, row);
+            CardsPanel.Children.Add(quickActionsCard);
+            
+            // 6. 网络信息卡片
+            if (col >= columnCount) { col = 0; row++; }
+            var networkCard = CreateNetworkInfoCard();
+            Grid.SetColumn(networkCard, col++);
+            Grid.SetRow(networkCard, row);
+            CardsPanel.Children.Add(networkCard);
+            
+            // 7. 天气卡片
+            if (col >= columnCount) { col = 0; row++; }
+            var weatherCard = CreateWeatherCard();
+            Grid.SetColumn(weatherCard, col++);
+            Grid.SetRow(weatherCard, row);
+            CardsPanel.Children.Add(weatherCard);
+            
+            // 8. 一言卡片
+            if (col >= columnCount) { col = 0; row++; }
+            var hitokotoCard = CreateHitokotoCard();
+            Grid.SetColumn(hitokotoCard, col++);
+            Grid.SetRow(hitokotoCard, row);
+            CardsPanel.Children.Add(hitokotoCard);
+        }
 
-            //欢迎头部文本
-            Home_SP_Tip.ToolTip = Properties.Lang.ResourceManager.GetString("Hello", System.Globalization.CultureInfo.CurrentUICulture) + Convert.ToChar(32) + Environment.UserName;
+        #region 卡片创建方法
 
+        private Border CreateCard(string icon, string title, UIElement content)
+        {
+            var card = new Border
+            {
+                Margin = new Thickness(0, 0, 8, 12),
+                Padding = new Thickness(16,16,14,14),
+                CornerRadius = new CornerRadius(8),
+                BorderThickness = new Thickness(1),
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Top
+            };
+            
+            card.SetResourceReference(Border.BackgroundProperty, "CardBackgroundFillColorDefaultBrush");
+            card.SetResourceReference(Border.BorderBrushProperty, "CardStrokeColorDefaultBrush");
+            
+            card.Effect = new DropShadowEffect
+            {
+                Color = Colors.Black,
+                Direction = 270,
+                ShadowDepth = 2,
+                BlurRadius = 6,
+                Opacity = 0.15
+            };
+            
+            var stack = new StackPanel();
+            
+            // 标题
+            var headerPanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 0, 0, 12)
+            };
+            
+            var iconText = new TextBlock
+            {
+                Text = icon,
+                FontFamily = (FontFamily)Application.Current.TryFindResource("SegoeIcons") 
+                             ?? new FontFamily("Segoe MDL2 Assets"),
+                FontSize = 18,
+                Margin = new Thickness(0, 0, 8, 0),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            iconText.SetResourceReference(TextBlock.ForegroundProperty, "AccentTextFillColorPrimaryBrush");
+            
+            var titleText = new TextBlock
+            {
+                Text = title,
+                FontSize = 15,
+                FontWeight = FontWeights.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center,
+                FontFamily = new FontFamily("Microsoft YaHei UI, Segoe UI")
+            };
+            titleText.SetResourceReference(TextBlock.ForegroundProperty, "AccentTextFillColorPrimaryBrush");
+            
+            headerPanel.Children.Add(iconText);
+            headerPanel.Children.Add(titleText);
+            stack.Children.Add(headerPanel);
+            
+            // 分隔线
+            var separator = new Border
+            {
+                Height = 1,
+                Margin = new Thickness(0, 0, 0, 10)
+            };
+            separator.SetResourceReference(Border.BackgroundProperty, "DividerStrokeColorDefaultBrush");
+            stack.Children.Add(separator);
+            
+            // 内容
+            stack.Children.Add(content);
+            
+            card.Child = stack;
+            return card;
+        }
 
-            //一言卡片获取
+        private Border CreateSystemTimeCard()
+        {
+            var content = new StackPanel();
+            
+            var startTimeLabel = new TextBlock
+            {
+                Text = Properties.Lang.ResourceManager.GetString("SystemStartTime", 
+                    System.Globalization.CultureInfo.CurrentUICulture),
+                FontSize = 13,
+                Margin = new Thickness(0, 0, 0, 5)
+            };
+            startTimeLabel.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            
+            var openTime = new TextBlock
+            {
+                Name = "OpenTime",
+                Text = UPTime.ToLongDateString(),
+                FontSize = 14,
+                FontWeight = FontWeights.Medium,
+                Margin = new Thickness(0, 0, 0, 12)
+            };
+            openTime.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
+            RegisterName("OpenTimeText", openTime);
+            
+            var runTimeLabel = new TextBlock
+            {
+                Text = Properties.Lang.ResourceManager.GetString("SystemRunTime", 
+                    System.Globalization.CultureInfo.CurrentUICulture),
+                FontSize = 13,
+                Margin = new Thickness(0, 0, 0, 5)
+            };
+            runTimeLabel.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            
+            var runTime = new TextBlock
+            {
+                Name = "RunTime",
+                Text = "...",
+                FontSize = 14,
+                FontWeight = FontWeights.Medium,
+                FontFamily = new FontFamily("Consolas, Microsoft YaHei UI")
+            };
+            runTime.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
+            RegisterName("RunTimeText", runTime);
+            
+            content.Children.Add(startTimeLabel);
+            content.Children.Add(openTime);
+            content.Children.Add(runTimeLabel);
+            content.Children.Add(runTime);
+            
+            return CreateCard("\uE2AD", Properties.Lang.ResourceManager.GetString("SystemTime", 
+                System.Globalization.CultureInfo.CurrentUICulture), content);
+        }
+
+        private Border CreateSystemInfoCard()
+        {
+            var content = new StackPanel();
+            
+            // 获取系统信息
+            string osName = "", osVersion = "";
             try
             {
-                System.Net.Http.HttpResponseMessage response = await client.GetAsync("https://v1.hitokoto.cn/?c=b&c=a&encode=text");
+                using (ManagementObjectSearcher OpSystem = new ManagementObjectSearcher("SELECT * FROM Win32_OperatingSystem"))
+                {
+                    foreach (ManagementObject OpSys in OpSystem.Get())
+                    {
+                        osName = OpSys.GetPropertyValue("Caption")?.ToString() ?? "Unknown";
+                        osVersion = OpSys.GetPropertyValue("Version")?.ToString() ?? "Unknown";
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error getting OS info: {ex}");
+                osName = "Windows";
+                osVersion = "Unknown";
+            }
+            
+            var nameText = new TextBlock
+            {
+                Text = osName,
+                FontSize = 13,
+                FontWeight = FontWeights.Medium,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            nameText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
+            
+            var versionText = new TextBlock
+            {
+                Text = $"{Properties.Lang.ResourceManager.GetString("Version", System.Globalization.CultureInfo.CurrentUICulture)}: {osVersion}",
+                FontSize = 12,
+                TextWrapping = TextWrapping.Wrap
+            };
+            versionText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            
+            content.Children.Add(nameText);
+            content.Children.Add(versionText);
+            
+            return CreateCard("\uE7F8", Properties.Lang.ResourceManager.GetString("CurrentSystem", 
+                System.Globalization.CultureInfo.CurrentUICulture), content);
+        }
+
+        private Border CreateResourceMonitorCard()
+        {
+            var content = new StackPanel();
+            
+            // CPU
+            var cpuRow = CreateResourceRow("CPU", out cpuValueText, out cpuProgressBar);
+            content.Children.Add(cpuRow);
+            
+            // 内存
+            var memRow = CreateResourceRow(Properties.Lang.ResourceManager.GetString("Memory", 
+                System.Globalization.CultureInfo.CurrentUICulture) ?? "内存", out memValueText, out memProgressBar);
+            content.Children.Add(memRow);
+            
+            // 磁盘
+            var diskRow = CreateResourceRow(Properties.Lang.ResourceManager.GetString("Disk", 
+                System.Globalization.CultureInfo.CurrentUICulture) ?? "磁盘", out diskValueText, out diskProgressBar);
+            content.Children.Add(diskRow);
+            
+            return CreateCard("\uE950", Properties.Lang.ResourceManager.GetString("SystemResources", 
+                System.Globalization.CultureInfo.CurrentUICulture) ?? "系统资源", content);
+        }
+
+        private StackPanel CreateResourceRow(string label, out TextBlock valueText, out Border progressBar)
+        {
+            var row = new StackPanel { Margin = new Thickness(0, 0, 0, 10) };
+            
+            var headerGrid = new Grid();
+            headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            
+            var labelText = new TextBlock
+            {
+                Text = label,
+                FontSize = 12,
+                Margin = new Thickness(0, 0, 0, 4)
+            };
+            labelText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            Grid.SetColumn(labelText, 0);
+            
+            valueText = new TextBlock
+            {
+                Text = "0%",
+                FontSize = 12,
+                FontWeight = FontWeights.Medium,
+                FontFamily = new FontFamily("Consolas"),
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 0, 0, 4)
+            };
+            valueText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
+            Grid.SetColumn(valueText, 1);
+            
+            headerGrid.Children.Add(labelText);
+            headerGrid.Children.Add(valueText);
+            row.Children.Add(headerGrid);
+            
+            // 进度条背景
+            var progressBackground = new Border
+            {
+                Height = 6,
+                CornerRadius = new CornerRadius(3)
+            };
+            progressBackground.SetResourceReference(Border.BackgroundProperty, "ControlStrokeColorDefaultBrush");
+            
+            // 进度条前景
+            progressBar = new Border
+            {
+                Height = 6,
+                CornerRadius = new CornerRadius(3),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Width = 0
+            };
+            progressBar.Background = new SolidColorBrush(Color.FromRgb(0, 120, 212));
+            
+            var progressGrid = new Grid();
+            progressGrid.Children.Add(progressBackground);
+            progressGrid.Children.Add(progressBar);
+            row.Children.Add(progressGrid);
+            
+            return row;
+        }
+
+        private Border CreateSystemHealthCard()
+        {
+            var content = new StackPanel();
+            
+            var statusPanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            
+            var statusIcon = new TextBlock
+            {
+                Name = "HealthIcon",
+                Text = "🟢",
+                FontSize = 20,
+                Margin = new Thickness(0, 0, 10, 0),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            RegisterName("HealthIcon", statusIcon);
+            
+            var statusText = new TextBlock
+            {
+                Name = "HealthStatus",
+                Text = Properties.Lang.ResourceManager.GetString("SystemHealthGood", 
+                    System.Globalization.CultureInfo.CurrentUICulture) ?? "良好",
+                FontSize = 16,
+                FontWeight = FontWeights.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            statusText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
+            RegisterName("HealthStatus", statusText);
+            
+            statusPanel.Children.Add(statusIcon);
+            statusPanel.Children.Add(statusText);
+            content.Children.Add(statusPanel);
+            
+            var detailsText = new TextBlock
+            {
+                Name = "HealthDetails",
+                Text = "温度: 正常 | 性能: 良好",
+                FontSize = 12,
+                TextWrapping = TextWrapping.Wrap
+            };
+            detailsText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            RegisterName("HealthDetails", detailsText);
+            content.Children.Add(detailsText);
+            
+            return CreateCard("\uEA37", Properties.Lang.ResourceManager.GetString("SystemHealth", 
+                System.Globalization.CultureInfo.CurrentUICulture) ?? "系统健康", content);
+        }
+
+        private Border CreateQuickActionsCard()
+        {
+            var content = new UniformGrid
+            {
+                Columns = 3,
+                Rows = 2
+            };
+            
+            // 创建快速操作按钮
+            content.Children.Add(CreateActionButton("\uE7E8", "重启", () => ExecuteSystemCommand("shutdown /r /t 0")));
+            content.Children.Add(CreateActionButton("\uE7E8", "关机", () => ExecuteSystemCommand("shutdown /s /t 0")));
+            content.Children.Add(CreateActionButton("\uE708", "睡眠", () => ExecuteSystemCommand("rundll32.exe powrprof.dll,SetSuspendState 0,1,0")));
+            content.Children.Add(CreateActionButton("\uE74D", "清理", () => ExecuteSystemCommand("cleanmgr")));
+            content.Children.Add(CreateActionButton("\uE8B8", "任务管理器", () => Process.Start("taskmgr")));
+            content.Children.Add(CreateActionButton("\uE713", "设置", () => ExecuteSystemCommand("ms-settings:")));
+            
+            return CreateCard("\uE90F", Properties.Lang.ResourceManager.GetString("QuickActions", 
+                System.Globalization.CultureInfo.CurrentUICulture) ?? "快速操作", content);
+        }
+
+        private Button CreateActionButton(string icon, string label, Action action)
+        {
+            var button = new Button
+            {
+                Margin = new Thickness(2),
+                Padding = new Thickness(5),
+                Height = 50,
+                Background = Brushes.Transparent,
+                BorderThickness = new Thickness(1)
+            };
+            button.SetResourceReference(Button.BorderBrushProperty, "ControlStrokeColorDefaultBrush");
+            
+            var stack = new StackPanel { HorizontalAlignment = HorizontalAlignment.Center };
+            
+            var iconText = new TextBlock
+            {
+                Text = icon,
+                FontFamily = (FontFamily)Application.Current.TryFindResource("SegoeIcons") 
+                             ?? new FontFamily("Segoe MDL2 Assets"),
+                FontSize = 16,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 2)
+            };
+            iconText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
+            
+            var labelText = new TextBlock
+            {
+                Text = label,
+                FontSize = 11,
+                HorizontalAlignment = HorizontalAlignment.Center
+            };
+            labelText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            
+            stack.Children.Add(iconText);
+            stack.Children.Add(labelText);
+            button.Content = stack;
+            
+            button.Click += (s, e) =>
+            {
+                try
+                {
+                    action?.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Error executing action: {ex}");
+                    MessageBox.Show($"执行操作失败: {ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            };
+            
+            return button;
+        }
+
+        private Border CreateNetworkInfoCard()
+        {
+            var content = new StackPanel();
+            
+            var ipv4Panel = CreateIPPanel("IPv4", out TextBlock ipv4Text, IPv4_MouseLeftButtonDown, IPv4_MouseRightButtonDown);
+            RegisterName("IPv4Text", ipv4Text);
+            content.Children.Add(ipv4Panel);
+            
+            var ipv6Panel = CreateIPPanel("IPv6", out TextBlock ipv6Text, IPv6_MouseLeftButtonDown, IPv6_MouseRightButtonDown);
+            RegisterName("IPv6Text", ipv6Text);
+            content.Children.Add(ipv6Panel);
+            
+            var providerText = new TextBlock
+            {
+                Text = Properties.Lang.ResourceManager.GetString("ServiceProvider", 
+                    System.Globalization.CultureInfo.CurrentUICulture),
+                FontSize = 10,
+                Margin = new Thickness(0, 8, 0, 0)
+            };
+            providerText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorTertiaryBrush");
+            content.Children.Add(providerText);
+            
+            return CreateCard("\uE968", Properties.Lang.ResourceManager.GetString("IP", 
+                System.Globalization.CultureInfo.CurrentUICulture), content);
+        }
+
+        private StackPanel CreateIPPanel(string label, out TextBlock valueText, 
+            MouseButtonEventHandler leftClick, MouseButtonEventHandler rightClick)
+        {
+            var panel = new StackPanel { Margin = new Thickness(0, 0, 0, 8) };
+            
+            var labelText = new TextBlock
+            {
+                Text = label + ":",
+                FontSize = 12,
+                Margin = new Thickness(0, 0, 0, 4)
+            };
+            labelText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            
+            valueText = new TextBlock
+            {
+                Text = "***.***.***.**" + (label == "IPv6" ? "*" : ""),
+                FontSize = 13,
+                FontFamily = new FontFamily("Consolas"),
+                Cursor = Cursors.Hand,
+                ToolTip = Properties.Lang.ResourceManager.GetString("LR_ToolTip", 
+                    System.Globalization.CultureInfo.CurrentUICulture)
+            };
+            valueText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
+            valueText.MouseLeftButtonDown += leftClick;
+            valueText.MouseRightButtonDown += rightClick;
+            
+            panel.Children.Add(labelText);
+            panel.Children.Add(valueText);
+            
+            return panel;
+        }
+
+        private Border CreateWeatherCard()
+        {
+            var content = new StackPanel();
+            
+            var weatherPanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            
+            var weatherIcon = new TextBlock
+            {
+                Name = "WeatherIcon",
+                Text = "☀️",
+                FontSize = 32,
+                Margin = new Thickness(0, 0, 10, 0)
+            };
+            RegisterName("WeatherIcon", weatherIcon);
+            
+            var weatherInfo = new StackPanel();
+            
+            var tempText = new TextBlock
+            {
+                Name = "WeatherTemp",
+                Text = "--°C",
+                FontSize = 20,
+                FontWeight = FontWeights.SemiBold
+            };
+            tempText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
+            RegisterName("WeatherTemp", tempText);
+            
+            var locationText = new TextBlock
+            {
+                Name = "WeatherLocation",
+                Text = Properties.Lang.ResourceManager.GetString("LoadingWeather", 
+                    System.Globalization.CultureInfo.CurrentUICulture) ?? "加载中...",
+                FontSize = 11
+            };
+            locationText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            RegisterName("WeatherLocation", locationText);
+            
+            weatherInfo.Children.Add(tempText);
+            weatherInfo.Children.Add(locationText);
+            
+            weatherPanel.Children.Add(weatherIcon);
+            weatherPanel.Children.Add(weatherInfo);
+            content.Children.Add(weatherPanel);
+            
+            return CreateCard("\uE753", Properties.Lang.ResourceManager.GetString("Weather", 
+                System.Globalization.CultureInfo.CurrentUICulture) ?? "天气", content);
+        }
+
+        private Border CreateHitokotoCard()
+        {
+            var content = new TextBlock
+            {
+                Name = "HitokotoText",
+                Text = Properties.Lang.ResourceManager.GetString("LoadingHitokoto", 
+                    System.Globalization.CultureInfo.CurrentUICulture) ?? "Now loading",
+                FontSize = 13,
+                TextWrapping = TextWrapping.Wrap,
+                FontStyle = FontStyles.Italic,
+                LineHeight = 20
+            };
+            content.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
+            RegisterName("HitokotoText", content);
+            
+            return CreateCard("\uE8F2", Properties.Lang.ResourceManager.GetString("Hitokoto", 
+                System.Globalization.CultureInfo.CurrentUICulture) ?? "一言", content);
+        }
+
+        #endregion
+
+        #region 更新方法
+
+        private void RefreshLanguageCache()
+        {
+            isChineseLanguage = System.Globalization.CultureInfo.CurrentUICulture.Name.StartsWith("zh");
+            dayUnit = Properties.Lang.ResourceManager.GetString("TimeUnitDay", System.Globalization.CultureInfo.CurrentUICulture) ?? "天";
+            hourUnit = Properties.Lang.ResourceManager.GetString("TimeUnitHour", System.Globalization.CultureInfo.CurrentUICulture) ?? "时";
+            minuteUnit = Properties.Lang.ResourceManager.GetString("TimeUnitMinute", System.Globalization.CultureInfo.CurrentUICulture) ?? "分";
+            secondUnit = Properties.Lang.ResourceManager.GetString("TimeUnitSecond", System.Globalization.CultureInfo.CurrentUICulture) ?? "秒";
+        }
+
+        private void UpdateTimeDisplay()
+        {
+            try
+            {
+                TimeSpan Nows = DateTime.Now - UPTime;
+                string RunTime_ = $"{Nows.Days} {dayUnit} {Nows.Hours} {hourUnit} {Nows.Minutes} {minuteUnit} {Nows.Seconds} {secondUnit}";
+                
+                if (FindName("RunTimeText") is TextBlock runTimeText)
+                {
+                    runTimeText.Text = RunTime_;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error updating time: {ex}");
+            }
+        }
+
+        private void UpdateResourceMonitor()
+        {
+            try
+            {
+                // CPU
+                float cpuUsage = cpuCounter?.NextValue() ?? 0;
+                UpdateResourceDisplay(cpuValueText, cpuProgressBar, cpuUsage);
+                
+                // 内存
+                float memUsage = ramCounter?.NextValue() ?? 0;
+                UpdateResourceDisplay(memValueText, memProgressBar, memUsage);
+                
+                // 磁盘（获取C盘使用率）
+                float diskUsage = GetDiskUsage();
+                UpdateResourceDisplay(diskValueText, diskProgressBar, diskUsage);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error updating resources: {ex}");
+            }
+        }
+
+        private void UpdateResourceDisplay(TextBlock valueText, Border progressBar, float percentage)
+        {
+            if (valueText == null || progressBar == null) return;
+            
+            valueText.Text = $"{percentage:F0}%";
+            
+            // 动画更新进度条
+            double targetWidth = (progressBar.Parent as Grid)?.ActualWidth * (percentage / 100.0) ?? 0;
+            var animation = new DoubleAnimation
+            {
+                To = Math.Max(0, targetWidth),
+                Duration = TimeSpan.FromMilliseconds(300),
+                EasingFunction = new QuadraticEase()
+            };
+            progressBar.BeginAnimation(FrameworkElement.WidthProperty, animation);
+            
+            // 根据使用率设置颜色
+            Color color;
+            if (percentage < 60)
+                color = Color.FromRgb(16, 185, 129); // 绿色
+            else if (percentage < 85)
+                color = Color.FromRgb(245, 158, 11); // 黄色
+            else
+                color = Color.FromRgb(239, 68, 68); // 红色
+                
+            var colorAnimation = new ColorAnimation
+            {
+                To = color,
+                Duration = TimeSpan.FromMilliseconds(300)
+            };
+            progressBar.Background.BeginAnimation(SolidColorBrush.ColorProperty, colorAnimation);
+        }
+
+        private float GetDiskUsage()
+        {
+            try
+            {
+                var drive = new System.IO.DriveInfo("C");
+                if (drive.IsReady)
+                {
+                    double usedSpace = drive.TotalSize - drive.AvailableFreeSpace;
+                    return (float)(usedSpace / drive.TotalSize * 100.0);
+                }
+            }
+            catch { }
+            return 0;
+        }
+
+        private void UpdateSystemHealth()
+        {
+            try
+            {
+                float cpuUsage = cpuCounter?.NextValue() ?? 0;
+                float memUsage = ramCounter?.NextValue() ?? 0;
+                
+                string status, icon;
+                if (cpuUsage < 70 && memUsage < 80)
+                {
+                    status = Properties.Lang.ResourceManager.GetString("SystemHealthGood", 
+                        System.Globalization.CultureInfo.CurrentUICulture) ?? "良好";
+                    icon = "🟢";
+                }
+                else if (cpuUsage < 85 && memUsage < 90)
+                {
+                    status = Properties.Lang.ResourceManager.GetString("SystemHealthWarning", 
+                        System.Globalization.CultureInfo.CurrentUICulture) ?? "警告";
+                    icon = "🟡";
+                }
+                else
+                {
+                    status = Properties.Lang.ResourceManager.GetString("SystemHealthCritical", 
+                        System.Globalization.CultureInfo.CurrentUICulture) ?? "严重";
+                    icon = "🔴";
+                }
+                
+                if (FindName("HealthIcon") is TextBlock healthIcon)
+                    healthIcon.Text = icon;
+                    
+                if (FindName("HealthStatus") is TextBlock healthStatus)
+                    healthStatus.Text = status;
+                    
+                if (FindName("HealthDetails") is TextBlock healthDetails)
+                {
+                    healthDetails.Text = $"CPU: {cpuUsage:F0}% | " + 
+                        Properties.Lang.ResourceManager.GetString("Memory", System.Globalization.CultureInfo.CurrentUICulture) + 
+                        $": {memUsage:F0}%";
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error updating system health: {ex}");
+            }
+        }
+
+        private async Task LoadHitokotoAsync()
+        {
+            try
+            {
+                var response = await client.GetAsync("https://v1.hitokoto.cn/?c=b&c=a&encode=text");
                 response.EnsureSuccessStatusCode();
                 string webCode = await response.Content.ReadAsStringAsync();
-                Hitokoto.Text = webCode;
+                
+                if (FindName("HitokotoText") is TextBlock hitokotoText)
+                {
+                    hitokotoText.Text = webCode;
+                }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Hitokoto.Text = "！- " + Properties.Lang.ResourceManager.GetString("NetError", System.Globalization.CultureInfo.CurrentUICulture) + " - ！";
+                Debug.WriteLine($"Error loading hitokoto: {ex}");
+                if (FindName("HitokotoText") is TextBlock hitokotoText)
+                {
+                    hitokotoText.Text = Properties.Lang.ResourceManager.GetString("NetError", 
+                        System.Globalization.CultureInfo.CurrentUICulture) ?? "网络错误";
+                }
             }
+        }
 
-            if (Hitokoto.Text == "！- " + Properties.Lang.ResourceManager.GetString("NetError", System.Globalization.CultureInfo.CurrentUICulture) + " - ！")
-            {
-                IPv4.Text = "!";
-                IPv6.Text = "!";
-            }
-
-            // 获取Windows系统版本与版本号
-            ManagementObjectSearcher OpSystem = new ManagementObjectSearcher("SELECT * FROM Win32_OperatingSystem");
-            ManagementObjectCollection OpS = OpSystem.Get();
-            foreach (ManagementObject OpSys in OpS)
-            {
-                Windows_Name.Text = OpSys.GetPropertyValue("Caption").ToString();
-                Windows_Version.Text = OpSys.GetPropertyValue("Version").ToString();
-            }
-
-            // 获取公告
+        private async Task LoadWeatherAsync()
+        {
+            // 简化版天气API（这里可以接入真实的天气API）
             try
             {
-                // 根据当前语言选择公告URL
-                string noticeUrl = System.Globalization.CultureInfo.CurrentUICulture.Name.StartsWith("zh") 
-                    ? "https://systools.hksstudio.work/PublicNotice"          // 中文公告 Notice变更News但Url不修改
-                    : "https://systools.hksstudio.work/PublicNotice_EN";      // 英文公告
+                // 示例：可以接入和风天气、OpenWeatherMap等API
+                await Task.Delay(100); // 模拟请求
+                
+                // 这里需要实际的天气API，暂时显示占位符
+                if (FindName("WeatherTemp") is TextBlock tempText)
+                    tempText.Text = "--°C";
+                    
+                if (FindName("WeatherLocation") is TextBlock locationText)
+                {
+                    locationText.Text = Properties.Lang.ResourceManager.GetString("WeatherNotConfigured", 
+                        System.Globalization.CultureInfo.CurrentUICulture) ?? "未配置天气服务";
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error loading weather: {ex}");
+            }
+        }
 
-                HttpResponseMessage response = await client.GetAsync(noticeUrl);
+        private async Task LoadNoticesAsync()
+        {
+            try
+            {
+                string noticeUrl = isChineseLanguage 
+                    ? "https://systools.hksstudio.work/PublicNotice"
+                    : "https://systools.hksstudio.work/PublicNotice_EN";
+
+                var response = await client.GetAsync(noticeUrl);
                 response.EnsureSuccessStatusCode();
                 string noticeContent = await response.Content.ReadAsStringAsync();
                 
-                // 按行分割公告内容
                 notices = noticeContent.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries)
                                      .Select(n => n.Trim())
                                      .Where(n => !string.IsNullOrEmpty(n))
@@ -125,58 +918,42 @@ namespace SYSTools.Pages
 
                 if (notices.Count > 0)
                 {
-                    string firstNotice = notices[0];
-                    PublicNews.Text = firstNotice;
+                    PublicNews.Text = notices[0];
                     
                     if (notices.Count > 1)
                     {
-                        // 设置初始间隔
-                        noticeTimer.Interval = firstNotice.Length > 15 ? 
+                        noticeTimer.Interval = notices[0].Length > 15 ? 
                             TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(3);
                         noticeTimer.Start();
                     }
                 }
                 else
                 {
-                    PublicNews.Text = Properties.Lang.ResourceManager.GetString("NoticeInfo", System.Globalization.CultureInfo.CurrentUICulture);
+                    PublicNews.Text = Properties.Lang.ResourceManager.GetString("NoticeInfo", 
+                        System.Globalization.CultureInfo.CurrentUICulture);
                 }
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"获取公告失败: {ex}");
-                PublicNews.Text = Properties.Lang.ResourceManager.GetString("NoticeError", System.Globalization.CultureInfo.CurrentUICulture);
+                Debug.WriteLine($"Error loading notices: {ex}");
+                PublicNews.Text = Properties.Lang.ResourceManager.GetString("NoticeError", 
+                    System.Globalization.CultureInfo.CurrentUICulture);
             }
         }
 
-        private void RefreshLanguageCache()
-        {
-            isChineseLanguage = System.Globalization.CultureInfo.CurrentUICulture.Name.StartsWith("zh");
-            dayUnit = Properties.Lang.ResourceManager.GetString("TimeUnitDay", System.Globalization.CultureInfo.CurrentUICulture);
-            hourUnit = Properties.Lang.ResourceManager.GetString("TimeUnitHour", System.Globalization.CultureInfo.CurrentUICulture);
-            minuteUnit = Properties.Lang.ResourceManager.GetString("TimeUnitMinute", System.Globalization.CultureInfo.CurrentUICulture);
-            secondUnit = Properties.Lang.ResourceManager.GetString("TimeUnitSecond", System.Globalization.CultureInfo.CurrentUICulture);
-        }
+        #endregion
 
-        private void UpdateTimeDisplay()
-        {
-            TimeSpan Nows = DateTime.Now - UPTime;
-            string RunTime_ = $"{Nows.Days} {dayUnit} {Nows.Hours} {hourUnit} {Nows.Minutes} {minuteUnit} {Nows.Seconds} {secondUnit}";
-            
-            // 清空两个控件，然后只更新目标控件（避免闪烁）
-            if (isChineseLanguage)
-            {
-                RunTime.Text = RunTime_;
-            }
-            else
-            {
-                OpenTime.Text = RunTime_;
-            }
-        }
+        #region 定时器事件
 
         private void Timer_Tick(object sender, EventArgs e)
         {
             UpdateTimeDisplay();
-            CommandManager.InvalidateRequerySuggested();
+        }
+
+        private void ResourceTimer_Tick(object sender, EventArgs e)
+        {
+            UpdateResourceMonitor();
+            UpdateSystemHealth();
         }
 
         private void NoticeTimer_Tick(object sender, EventArgs e)
@@ -188,20 +965,18 @@ namespace SYSTools.Pages
                 string nextNotice = notices[currentNoticeIndex];
                 PublicNews.Text = nextNotice;
                 
-                // 根据文本长度调整显示时间
                 int textLength = nextNotice.Length;
                 TimeSpan interval = textLength > 15 ? TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(3);
                 noticeTimer.Interval = interval;
 
-                PublicNews.BeginAnimation(UIElement.OpacityProperty, new DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(500)));
+                PublicNews.BeginAnimation(UIElement.OpacityProperty, 
+                    new DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(500)));
             }
         }
 
-        private void Home_Unloaded(object sender, RoutedEventArgs e)
-        {
-            mainTimer?.Stop();
-            noticeTimer?.Stop();
-        }
+        #endregion
+
+        #region IP 获取方法
 
         private void IPv4_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
@@ -210,7 +985,8 @@ namespace SYSTools.Pages
 
         private void IPv4_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            IPv4.Text = "***.***.***.***";
+            if (FindName("IPv4Text") is TextBlock ipv4Text)
+                ipv4Text.Text = "***.***.***.***";
         }
 
         private void IPv6_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -220,41 +996,99 @@ namespace SYSTools.Pages
 
         private void IPv6_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
-            IPv6.Text = "****:****:****:****:****:****:****:****";
+            if (FindName("IPv6Text") is TextBlock ipv6Text)
+                ipv6Text.Text = "****:****:****:****:****:****:****:****";
         }
 
         private async void IPv4_Info()
         {
+            if (!(FindName("IPv4Text") is TextBlock ipv4Text)) return;
+            
             try
             {
-                this.IPv4.Text = "Now Loading...";
-                HttpResponseMessage IPv4Test = await client.GetAsync("https://myip.ipip.net/");
-                IPv4Test.EnsureSuccessStatusCode();
-                string IPv4 = await IPv4Test.Content.ReadAsStringAsync();
-                this.IPv4.Text = Regex.Replace(IPv4, "[\r\n]", "");
+                ipv4Text.Text = Properties.Lang.ResourceManager.GetString("Loading", 
+                    System.Globalization.CultureInfo.CurrentUICulture) ?? "Loading...";
+                    
+                var response = await client.GetAsync("https://myip.ipip.net/");
+                response.EnsureSuccessStatusCode();
+                string IPv4 = await response.Content.ReadAsStringAsync();
+                ipv4Text.Text = Regex.Replace(IPv4, "[\r\n]", "");
             }
-            catch (Exception IPv4Error)
+            catch (Exception ex)
             {
-                IPv4.Text = "当前网络可能没有IPV4地址或获取失败";
-                Debug.WriteLine(IPv4Error);
+                Debug.WriteLine($"Error getting IPv4: {ex}");
+                ipv4Text.Text = Properties.Lang.ResourceManager.GetString("IPv4Error", 
+                    System.Globalization.CultureInfo.CurrentUICulture) ?? "获取失败";
             }
         }
 
         private async void IPv6_Info()
         {
+            if (!(FindName("IPv6Text") is TextBlock ipv6Text)) return;
+            
             try
             {
-                this.IPv6.Text = "Now Loading...";
-                HttpResponseMessage IPv6Test = await client.GetAsync("https://speed.neu6.edu.cn/getIP.php");
-                IPv6Test.EnsureSuccessStatusCode();
-                string IPv6 = await IPv6Test.Content.ReadAsStringAsync();
-                this.IPv6.Text = "当前IPv6地址 : " + IPv6;
+                ipv6Text.Text = Properties.Lang.ResourceManager.GetString("Loading", 
+                    System.Globalization.CultureInfo.CurrentUICulture) ?? "Loading...";
+                    
+                var response = await client.GetAsync("https://speed.neu6.edu.cn/getIP.php");
+                response.EnsureSuccessStatusCode();
+                string IPv6 = await response.Content.ReadAsStringAsync();
+                ipv6Text.Text = IPv6;
             }
-            catch (Exception IPv6Error)
+            catch (Exception ex)
             {
-                IPv6.Text = "当前网络可能没有IPV6地址或获取失败";
-                Debug.WriteLine(IPv6Error);
+                Debug.WriteLine($"Error getting IPv6: {ex}");
+                ipv6Text.Text = Properties.Lang.ResourceManager.GetString("IPv6Error", 
+                    System.Globalization.CultureInfo.CurrentUICulture) ?? "获取失败";
             }
         }
+
+        #endregion
+
+        #region 快速操作方法
+
+        private void ExecuteSystemCommand(string command)
+        {
+            try
+            {
+                if (command.StartsWith("ms-settings:"))
+                {
+                    Process.Start(new ProcessStartInfo(command) { UseShellExecute = true });
+                }
+                else
+                {
+                    var result = MessageBox.Show(
+                        Properties.Lang.ResourceManager.GetString("ConfirmAction", 
+                            System.Globalization.CultureInfo.CurrentUICulture) ?? "确认执行此操作？",
+                        Properties.Lang.ResourceManager.GetString("Confirmation", 
+                            System.Globalization.CultureInfo.CurrentUICulture) ?? "确认",
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Question);
+                        
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        Process.Start(new ProcessStartInfo("cmd.exe", $"/c {command}") 
+                        { 
+                            CreateNoWindow = true,
+                            UseShellExecute = false 
+                        });
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error executing command: {ex}");
+                MessageBox.Show(
+                    Properties.Lang.ResourceManager.GetString("ExecutionError", 
+                        System.Globalization.CultureInfo.CurrentUICulture) ?? "执行失败",
+                    Properties.Lang.ResourceManager.GetString("Error", 
+                        System.Globalization.CultureInfo.CurrentUICulture) ?? "错误",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+        }
+
+        #endregion
     }
 }

--- a/SYSTools/Pages/Home.xaml.cs
+++ b/SYSTools/Pages/Home.xaml.cs
@@ -14,6 +14,9 @@ using System.Windows.Media.Animation;
 using System.Threading.Tasks;
 using System.Windows.Media.Effects;
 using System.Windows.Controls.Primitives;
+using System.ComponentModel;
+using SYSTools.Helpers;
+using MessageBox = iNKORE.UI.WPF.Modern.Controls.MessageBox;
 
 namespace SYSTools.Pages
 {
@@ -39,6 +42,8 @@ namespace SYSTools.Pages
         private PerformanceCounter ramCounter;
         private TextBlock cpuValueText, memValueText, diskValueText;
         private Border cpuProgressBar, memProgressBar, diskProgressBar;
+        private List<Border> allCards; // 缓存卡片列表
+        private bool isLanguageEventSubscribed = false; // 标记是否已订阅语言变化事件
 
         public Home()
         {
@@ -67,10 +72,90 @@ namespace SYSTools.Pages
             // 初始化公告计时器
             noticeTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
             noticeTimer.Tick += NoticeTimer_Tick;
+            
+            // 监听窗口大小变化，重新布局
+            this.SizeChanged += (s, e) =>
+            {
+                Dispatcher.BeginInvoke(new Action(() => BuildCardsLayout()), 
+                    System.Windows.Threading.DispatcherPriority.Background);
+            };
+            
+            // 订阅语言变化事件
+            SubscribeLanguageChanged();
+        }
+
+        // 订阅语言变化事件（防止重复订阅）
+        private void SubscribeLanguageChanged()
+        {
+            if (!isLanguageEventSubscribed)
+            {
+                LocalizationManager.Instance.PropertyChanged += OnLanguageChanged;
+                isLanguageEventSubscribed = true;
+            }
+        }
+        
+        private void OnLanguageChanged(object sender, PropertyChangedEventArgs e)
+        {
+            // LocalizationManager触发PropertyChanged时传递空字符串
+            // 所以我们不检查PropertyName，或者检查空字符串/null
+            if (string.IsNullOrEmpty(e.PropertyName) || e.PropertyName == nameof(LocalizationManager.CurrentCulture))
+            {
+                // 使用BeginInvoke确保在UI线程上执行
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    try
+                    {
+                        // 清空卡片缓存，强制重新创建
+                        allCards = null;
+                        
+                        // 刷新语言缓存
+                        RefreshLanguageCache();
+                        
+                        // 更新欢迎区域的用户名
+                        UsernameText.Text = Properties.Lang.ResourceManager.GetString("Hello", 
+                            System.Globalization.CultureInfo.CurrentUICulture) + " " + Environment.UserName;
+                        
+                        // 重新构建卡片布局（会重新创建所有卡片并应用新语言）
+                        BuildCardsLayout();
+                        
+                        // 重新加载一言（切换语言后加载对应语言的一言）
+                        _ = LoadHitokotoAsync();
+                        
+                        // 重新加载公告（切换语言后加载对应语言的公告）
+                        _ = LoadNoticesAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Home页面语言更新失败: {ex.Message}");
+                    }
+                }), System.Windows.Threading.DispatcherPriority.Normal);
+            }
+        }
+
+        // 安全注册名称的辅助方法
+        private void SafeRegisterName(string name, object scopedElement)
+        {
+            try
+            {
+                UnregisterName(name);
+            }
+            catch { }
+            
+            try
+            {
+                RegisterName(name, scopedElement);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error registering name {name}: {ex}");
+            }
         }
 
         private async void Page_Loaded(object sender, RoutedEventArgs e)
         {
+            // 确保语言变化事件已订阅（KeepAlive页面可能被重新加载）
+            SubscribeLanguageChanged();
+            
             // 刷新语言缓存
             RefreshLanguageCache();
             
@@ -109,87 +194,73 @@ namespace SYSTools.Pages
             resourceTimer?.Stop();
             cpuCounter?.Dispose();
             ramCounter?.Dispose();
+            
+            // 注意：不在这里取消订阅语言变化事件
+            // 因为页面使用 KeepAlive="True"，可能会被重新加载
+            // 事件订阅会在 Page_Loaded 中检查并确保存在
         }
 
         private void BuildCardsLayout()
         {
+            // 如果卡片已存在，先从父容器中移除
+            if (allCards != null)
+            {
+                foreach (var card in allCards)
+                {
+                    if (card.Parent is Panel parentPanel)
+                    {
+                        parentPanel.Children.Remove(card);
+                    }
+                }
+            }
+            
             CardsPanel.Children.Clear();
             CardsPanel.ColumnDefinitions.Clear();
             CardsPanel.RowDefinitions.Clear();
             
-            // 计算列数
+            // 计算列数 (每列约300px，默认3列)
             double availableWidth = this.ActualWidth - 50;
             if (availableWidth < 400) availableWidth = 1000;
-            int columnCount = Math.Max(2, (int)(availableWidth / 350));
+            int columnCount = Math.Max(2, (int)(availableWidth / 300));
             
-            // 创建列定义
+            // 创建列定义和列容器
+            var columnStacks = new List<StackPanel>();
             for (int i = 0; i < columnCount; i++)
             {
                 CardsPanel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                
+                var stackPanel = new StackPanel
+                {
+                    Orientation = Orientation.Vertical,
+                    Margin = new Thickness(0, 0, i < columnCount - 1 ? 8 : 0, 0) // 最后一列无右边距
+                };
+                Grid.SetColumn(stackPanel, i);
+                CardsPanel.Children.Add(stackPanel);
+                columnStacks.Add(stackPanel);
             }
             
-            // 创建行定义（3行）
-            for (int i = 0; i < 3; i++)
+            // 只在第一次调用时创建卡片
+            if (allCards == null)
             {
-                CardsPanel.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                allCards = new List<Border>
+                {
+                    CreateSystemTimeCard(),      // 1. 系统时间卡片
+                    CreateSystemInfoCard(),       // 2. 系统信息卡片
+                    CreateResourceMonitorCard(),  // 3. 系统资源卡片
+                    CreateSystemHealthCard(),     // 4. 系统健康卡片
+                    CreateQuickActionsCard(),     // 5. 快速操作卡片
+                    CreateNetworkInfoCard(),      // 6. 网络信息卡片
+                    CreateWeatherCard(),          // 7. 天气卡片
+                    CreateHitokotoCard()          // 8. 一言卡片
+                };
             }
             
-            int col = 0, row = 0;
-            
-            // 1. 系统时间卡片
-            var timeCard = CreateSystemTimeCard();
-            Grid.SetColumn(timeCard, col++);
-            Grid.SetRow(timeCard, row);
-            CardsPanel.Children.Add(timeCard);
-            
-            // 2. 系统信息卡片
-            if (col >= columnCount) { col = 0; row++; }
-            var sysInfoCard = CreateSystemInfoCard();
-            Grid.SetColumn(sysInfoCard, col++);
-            Grid.SetRow(sysInfoCard, row);
-            CardsPanel.Children.Add(sysInfoCard);
-            
-            // 3. 系统资源卡片
-            if (col >= columnCount) { col = 0; row++; }
-            var resourceCard = CreateResourceMonitorCard();
-            Grid.SetColumn(resourceCard, col++);
-            Grid.SetRow(resourceCard, row);
-            CardsPanel.Children.Add(resourceCard);
-            
-            // 4. 系统健康卡片
-            if (col >= columnCount) { col = 0; row++; }
-            var healthCard = CreateSystemHealthCard();
-            Grid.SetColumn(healthCard, col++);
-            Grid.SetRow(healthCard, row);
-            CardsPanel.Children.Add(healthCard);
-            
-            // 5. 快速操作卡片
-            if (col >= columnCount) { col = 0; row++; }
-            var quickActionsCard = CreateQuickActionsCard();
-            Grid.SetColumn(quickActionsCard, col++);
-            Grid.SetRow(quickActionsCard, row);
-            CardsPanel.Children.Add(quickActionsCard);
-            
-            // 6. 网络信息卡片
-            if (col >= columnCount) { col = 0; row++; }
-            var networkCard = CreateNetworkInfoCard();
-            Grid.SetColumn(networkCard, col++);
-            Grid.SetRow(networkCard, row);
-            CardsPanel.Children.Add(networkCard);
-            
-            // 7. 天气卡片
-            if (col >= columnCount) { col = 0; row++; }
-            var weatherCard = CreateWeatherCard();
-            Grid.SetColumn(weatherCard, col++);
-            Grid.SetRow(weatherCard, row);
-            CardsPanel.Children.Add(weatherCard);
-            
-            // 8. 一言卡片
-            if (col >= columnCount) { col = 0; row++; }
-            var hitokotoCard = CreateHitokotoCard();
-            Grid.SetColumn(hitokotoCard, col++);
-            Grid.SetRow(hitokotoCard, row);
-            CardsPanel.Children.Add(hitokotoCard);
+            // 将卡片轮询分配到各列
+            for (int i = 0; i < allCards.Count; i++)
+            {
+                int targetColumn = i % columnCount;
+                columnStacks[targetColumn].Children.Add(allCards[i]);
+            }
         }
 
         #region 卡片创建方法
@@ -198,8 +269,8 @@ namespace SYSTools.Pages
         {
             var card = new Border
             {
-                Margin = new Thickness(0, 0, 8, 12),
-                Padding = new Thickness(16,16,14,14),
+                Margin = new Thickness(0, 0, 0, 8),
+                Padding = new Thickness(16,14,16,14),
                 CornerRadius = new CornerRadius(8),
                 BorderThickness = new Thickness(1),
                 HorizontalAlignment = HorizontalAlignment.Stretch,
@@ -290,7 +361,7 @@ namespace SYSTools.Pages
                 Margin = new Thickness(0, 0, 0, 12)
             };
             openTime.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
-            RegisterName("OpenTimeText", openTime);
+            SafeRegisterName("OpenTimeText", openTime);
             
             var runTimeLabel = new TextBlock
             {
@@ -310,7 +381,7 @@ namespace SYSTools.Pages
                 FontFamily = new FontFamily("Consolas, Microsoft YaHei UI")
             };
             runTime.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
-            RegisterName("RunTimeText", runTime);
+            SafeRegisterName("RunTimeText", runTime);
             
             content.Children.Add(startTimeLabel);
             content.Children.Add(openTime);
@@ -469,7 +540,7 @@ namespace SYSTools.Pages
                 Margin = new Thickness(0, 0, 10, 0),
                 VerticalAlignment = VerticalAlignment.Center
             };
-            RegisterName("HealthIcon", statusIcon);
+            SafeRegisterName("HealthIcon", statusIcon);
             
             var statusText = new TextBlock
             {
@@ -481,7 +552,7 @@ namespace SYSTools.Pages
                 VerticalAlignment = VerticalAlignment.Center
             };
             statusText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
-            RegisterName("HealthStatus", statusText);
+            SafeRegisterName("HealthStatus", statusText);
             
             statusPanel.Children.Add(statusIcon);
             statusPanel.Children.Add(statusText);
@@ -495,7 +566,7 @@ namespace SYSTools.Pages
                 TextWrapping = TextWrapping.Wrap
             };
             detailsText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
-            RegisterName("HealthDetails", detailsText);
+            SafeRegisterName("HealthDetails", detailsText);
             content.Children.Add(detailsText);
             
             return CreateCard("\uEA37", Properties.Lang.ResourceManager.GetString("SystemHealth", 
@@ -529,6 +600,9 @@ namespace SYSTools.Pages
                 Margin = new Thickness(2),
                 Padding = new Thickness(5),
                 Height = 50,
+                Width = 80,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                VerticalContentAlignment = VerticalAlignment.Center,
                 Background = Brushes.Transparent,
                 BorderThickness = new Thickness(1)
             };
@@ -543,7 +617,7 @@ namespace SYSTools.Pages
                              ?? new FontFamily("Segoe MDL2 Assets"),
                 FontSize = 16,
                 HorizontalAlignment = HorizontalAlignment.Center,
-                Margin = new Thickness(0, 0, 0, 2)
+                Margin = new Thickness(0, 0, 0, 4)
             };
             iconText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
             
@@ -580,11 +654,11 @@ namespace SYSTools.Pages
             var content = new StackPanel();
             
             var ipv4Panel = CreateIPPanel("IPv4", out TextBlock ipv4Text, IPv4_MouseLeftButtonDown, IPv4_MouseRightButtonDown);
-            RegisterName("IPv4Text", ipv4Text);
+            SafeRegisterName("IPv4Text", ipv4Text);
             content.Children.Add(ipv4Panel);
             
             var ipv6Panel = CreateIPPanel("IPv6", out TextBlock ipv6Text, IPv6_MouseLeftButtonDown, IPv6_MouseRightButtonDown);
-            RegisterName("IPv6Text", ipv6Text);
+            SafeRegisterName("IPv6Text", ipv6Text);
             content.Children.Add(ipv6Panel);
             
             var providerText = new TextBlock
@@ -617,9 +691,12 @@ namespace SYSTools.Pages
             valueText = new TextBlock
             {
                 Text = "***.***.***.**" + (label == "IPv6" ? "*" : ""),
-                FontSize = 13,
-                FontFamily = new FontFamily("Consolas"),
+                FontSize = 12,
+                FontFamily = new FontFamily("Consolas, Microsoft YaHei UI"),
                 Cursor = Cursors.Hand,
+                TextWrapping = TextWrapping.Wrap,
+                MaxWidth = 280,
+                LineHeight = 18,
                 ToolTip = Properties.Lang.ResourceManager.GetString("LR_ToolTip", 
                     System.Globalization.CultureInfo.CurrentUICulture)
             };
@@ -650,7 +727,7 @@ namespace SYSTools.Pages
                 FontSize = 32,
                 Margin = new Thickness(0, 0, 10, 0)
             };
-            RegisterName("WeatherIcon", weatherIcon);
+            SafeRegisterName("WeatherIcon", weatherIcon);
             
             var weatherInfo = new StackPanel();
             
@@ -662,7 +739,7 @@ namespace SYSTools.Pages
                 FontWeight = FontWeights.SemiBold
             };
             tempText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorPrimaryBrush");
-            RegisterName("WeatherTemp", tempText);
+            SafeRegisterName("WeatherTemp", tempText);
             
             var locationText = new TextBlock
             {
@@ -672,7 +749,7 @@ namespace SYSTools.Pages
                 FontSize = 11
             };
             locationText.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
-            RegisterName("WeatherLocation", locationText);
+            SafeRegisterName("WeatherLocation", locationText);
             
             weatherInfo.Children.Add(tempText);
             weatherInfo.Children.Add(locationText);
@@ -698,7 +775,7 @@ namespace SYSTools.Pages
                 LineHeight = 20
             };
             content.SetResourceReference(TextBlock.ForegroundProperty, "TextFillColorSecondaryBrush");
-            RegisterName("HitokotoText", content);
+            SafeRegisterName("HitokotoText", content);
             
             return CreateCard("\uE8F2", Properties.Lang.ResourceManager.GetString("Hitokoto", 
                 System.Globalization.CultureInfo.CurrentUICulture) ?? "一言", content);
@@ -877,26 +954,156 @@ namespace SYSTools.Pages
 
         private async Task LoadWeatherAsync()
         {
-            // 简化版天气API（这里可以接入真实的天气API）
             try
             {
-                // 示例：可以接入和风天气、OpenWeatherMap等API
-                await Task.Delay(100); // 模拟请求
+                // 第一步：通过ip.sb获取地理位置
+                var ipResponse = await client.GetAsync("https://api.ip.sb/geoip");
+                ipResponse.EnsureSuccessStatusCode();
+                string ipData = await ipResponse.Content.ReadAsStringAsync();
                 
-                // 这里需要实际的天气API，暂时显示占位符
+                var city = ExtractJsonValue(ipData, "city");
+                var country = ExtractJsonValue(ipData, "country");
+                
+                if (string.IsNullOrEmpty(city))
+                {
+                    throw new Exception("无法获取城市信息");
+                }
+                
+                // 第二步：使用wttr.in API根据城市名获取天气
+                // 使用城市名查询，wttr.in会自动识别
+                var weatherUrl = $"https://wttr.in/{Uri.EscapeDataString(city)}?format=j1";
+                var weatherResponse = await client.GetAsync(weatherUrl);
+                weatherResponse.EnsureSuccessStatusCode();
+                string weatherData = await weatherResponse.Content.ReadAsStringAsync();
+                
+                // 解析wttr.in的JSON数据
+                var temp = ExtractJsonValue(weatherData, "temp_C");
+                var weatherDesc = ExtractJsonValue(weatherData, "weatherDesc");
+                
                 if (FindName("WeatherTemp") is TextBlock tempText)
-                    tempText.Text = "--°C";
-                    
+                {
+                    if (!string.IsNullOrEmpty(temp))
+                    {
+                        // 温度可能包含小数点，格式化为整数
+                        if (double.TryParse(temp, System.Globalization.NumberStyles.Any, 
+                            System.Globalization.CultureInfo.InvariantCulture, out double tempValue))
+                        {
+                            tempText.Text = $"{Math.Round(tempValue)}°C";
+                        }
+                        else
+                        {
+                            tempText.Text = $"{temp}°C";
+                        }
+                    }
+                    else
+                    {
+                        tempText.Text = "--°C";
+                    }
+                }
+                
                 if (FindName("WeatherLocation") is TextBlock locationText)
                 {
-                    locationText.Text = Properties.Lang.ResourceManager.GetString("WeatherNotConfigured", 
-                        System.Globalization.CultureInfo.CurrentUICulture) ?? "未配置天气服务";
+                    string location = "";
+                    if (!string.IsNullOrEmpty(city))
+                    {
+                        location = city;
+                        if (!string.IsNullOrEmpty(country) && country != city)
+                        {
+                            location += $", {country}";
+                        }
+                    }
+                    else if (!string.IsNullOrEmpty(country))
+                    {
+                        location = country;
+                    }
+                    else
+                    {
+                        location = Properties.Lang.ResourceManager.GetString("WeatherNotConfigured", 
+                            System.Globalization.CultureInfo.CurrentUICulture) ?? "未配置天气服务";
+                    }
+                    locationText.Text = location;
+                }
+                
+                if (FindName("WeatherIcon") is TextBlock iconText && !string.IsNullOrEmpty(weatherDesc))
+                {
+                    iconText.Text = GetWeatherEmojiFromDesc(weatherDesc);
                 }
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"Error loading weather: {ex}");
+                
+                if (FindName("WeatherTemp") is TextBlock tempText)
+                    tempText.Text = "--°C";
+                    
+                if (FindName("WeatherLocation") is TextBlock locationText)
+                {
+                    locationText.Text = Properties.Lang.ResourceManager.GetString("NetError", 
+                        System.Globalization.CultureInfo.CurrentUICulture) ?? "网络错误";
+                }
             }
+        }
+        
+        private string ExtractJsonValue(string json, string key)
+        {
+            try
+            {
+                // 尝试匹配字符串值："key":"value"
+                string pattern = $"\"{key}\"\\s*:\\s*\"([^\"]+)\"";
+                var match = Regex.Match(json, pattern);
+                if (match.Success)
+                {
+                    return match.Groups[1].Value;
+                }
+                
+                // 尝试匹配数字值："key":123 或 "key":123.45
+                pattern = $"\"{key}\"\\s*:\\s*([\\d\\.\\-]+)";
+                match = Regex.Match(json, pattern);
+                if (match.Success)
+                {
+                    return match.Groups[1].Value;
+                }
+                
+                // 尝试数组中的第一个元素
+                pattern = $"\"{key}\"\\s*:\\s*\\[\\s*{{[^}}]*\"value\"\\s*:\\s*\"([^\"]+)\"";
+                match = Regex.Match(json, pattern);
+                if (match.Success)
+                {
+                    return match.Groups[1].Value;
+                }
+            }
+            catch { }
+            return string.Empty;
+        }
+        
+        // 根据wttr.in天气描述转换为emoji图标
+        private string GetWeatherEmojiFromDesc(string weatherDesc)
+        {
+            if (string.IsNullOrEmpty(weatherDesc))
+                return "🌤️";
+            
+            weatherDesc = weatherDesc.ToLower();
+            
+            if (weatherDesc.Contains("sunny") || weatherDesc.Contains("clear"))
+                return "☀️";
+            else if (weatherDesc.Contains("partly cloudy") || weatherDesc.Contains("partly cloud"))
+                return "⛅";
+            else if (weatherDesc.Contains("cloudy") || weatherDesc.Contains("overcast"))
+                return "☁️";
+            else if (weatherDesc.Contains("mist") || weatherDesc.Contains("fog"))
+                return "🌫️";
+            else if (weatherDesc.Contains("thunder") || weatherDesc.Contains("storm"))
+                return "⛈️";
+            else if (weatherDesc.Contains("snow") || weatherDesc.Contains("blizzard"))
+                return "❄️";
+            else if (weatherDesc.Contains("sleet") || weatherDesc.Contains("ice"))
+                return "🌨️";
+            else if (weatherDesc.Contains("rain") || weatherDesc.Contains("drizzle") || weatherDesc.Contains("shower"))
+                return "🌧️";
+            else if (weatherDesc.Contains("wind"))
+                return "💨";
+            else
+                return "🌤️";
         }
 
         private async Task LoadNoticesAsync()

--- a/SYSTools/Pages/Test.xaml.cs
+++ b/SYSTools/Pages/Test.xaml.cs
@@ -188,12 +188,14 @@ namespace SYSTools.Pages
                             {
                                 string resolution = DeskTop_Info.GetPropertyValue("VideoModeDescription")?.ToString() ?? "未知";
                                 string refreshRate = DeskTop_Info.GetPropertyValue("CurrentRefreshRate")?.ToString() ?? "未知";
-                                resolutionInfo.Add($"{DeskTop_Info.GetPropertyValue("Name")}: {resolution} {refreshRate} Hz");
+                                resolutionInfo.Add($"{DeskTop_Info.GetPropertyValue("Name")}:");
+                                resolutionInfo.Add($"    {resolution} {refreshRate} Hz");
                             }
                         }
                         catch (NullReferenceException)
                         {
-                            resolutionInfo.Add($"{DeskTop_Info.GetPropertyValue("Name")}: 屏幕未接入");
+                            resolutionInfo.Add($"{DeskTop_Info.GetPropertyValue("Name")}:");
+                            resolutionInfo.Add($"    屏幕未接入");
                         }
                     }
                 }

--- a/SYSTools/Properties/Lang.Designer.cs
+++ b/SYSTools/Properties/Lang.Designer.cs
@@ -19,7 +19,7 @@ namespace SYSTools.Properties {
     // 类通过类似于 ResGen 或 Visual Studio 的工具自动生成的。
     // 若要添加或移除成员，请编辑 .ResX 文件，然后重新运行 ResGen
     // (以 /str 作为命令选项)，或重新生成 VS 项目。
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Lang {

--- a/SYSTools/Properties/Lang.en.resx
+++ b/SYSTools/Properties/Lang.en.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+    <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,437 +59,500 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+        <xsd:element name="root" msdata:IsDataSet="true">
             <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
+                <xsd:choice maxOccurs="unbounded">
+                    <xsd:element name="metadata">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" use="required" type="xsd:string" />
+                            <xsd:attribute name="type" type="xsd:string" />
+                            <xsd:attribute name="mimetype" type="xsd:string" />
+                            <xsd:attribute ref="xml:space" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="assembly">
+                        <xsd:complexType>
+                            <xsd:attribute name="alias" type="xsd:string" />
+                            <xsd:attribute name="name" type="xsd:string" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="data">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+                            <xsd:attribute ref="xml:space" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="resheader">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required" />
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
             </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
-  <resheader name="resmimetype">
-    <value>text/microsoft-resx</value>
-  </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
-  <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <data name="ContactUs" xml:space="preserve">
-    <value>Contact Us</value>
-  </data>
-  <data name="QQGroup" xml:space="preserve">
-    <value>QQ Group</value>
-  </data>
-  <data name="WebSite" xml:space="preserve">
-    <value>Website</value>
-  </data>
-  <data name="GithubRepo" xml:space="preserve">
-    <value>Github Repository</value>
-  </data>
-  <data name="Developers" xml:space="preserve">
-    <value>Developers &amp; Designers &amp; External Contributors</value>
-  </data>
-  <data name="ComponentsLicense" xml:space="preserve">
-    <value>Third-Party Libraries</value>
-  </data>
-  <data name="SYSToolsUpdate" xml:space="preserve">
-    <value>Update</value>
-  </data>
-  <data name="SoftwareToolkitUpdate" xml:space="preserve">
-    <value>Software &amp; Toolkit Update</value>
-  </data>
-  <data name="SoftwareUpdate" xml:space="preserve">
-    <value>Software Update</value>
-  </data>
-  <data name="ToolkitUpdate" xml:space="preserve">
-    <value>Toolkit Update</value>
-  </data>
-  <data name="PolicyAgreement" xml:space="preserve">
-    <value>Privacy Policy &amp; User Agreement</value>
-  </data>
-  <data name="PrivacyPolicy" xml:space="preserve">
-    <value>Privacy Policy</value>
-  </data>
-  <data name="UserAgreement" xml:space="preserve">
-    <value>User Agreement</value>
-  </data>
-  <data name="BackImageSetting_Description" xml:space="preserve">
-    <value>Preview and set the background image, blur, and opacity.</value>
-  </data>
-  <data name="BackImageSetting_Header" xml:space="preserve">
-    <value>Background &amp; Effects</value>
-  </data>
-  <data name="BackImagePreview" xml:space="preserve">
-    <value>Preview your background image</value>
-  </data>
-  <data name="SelectBackgroundImage" xml:space="preserve">
-    <value>Select</value>
-  </data>
-  <data name="ClearBackgroundImage" xml:space="preserve">
-    <value>Clear</value>
-  </data>
-  <data name="BackgroundImageBlurRadius_Description" xml:space="preserve">
-    <value>High blur settings may cause lag.</value>
-  </data>
-  <data name="BackgroundImageBlurRadius_Header" xml:space="preserve">
-    <value>Image Blur Effect (Experimental)</value>
-  </data>
-  <data name="BackgroundImageOpacity_Header" xml:space="preserve">
-    <value>Image Opacity (Experimental)</value>
-  </data>
-  <data name="ProgramThemeSetting_Header" xml:space="preserve">
-    <value>Themes</value>
-  </data>
-  <data name="ProgramThemeSetting_Description" xml:space="preserve">
-    <value>Choose a light/dark theme.</value>
-  </data>
-  <data name="ThemeModeSetting_Auto" xml:space="preserve">
-    <value>Auto</value>
-  </data>
-  <data name="ThemeModeSetting_Dark" xml:space="preserve">
-    <value>Dark</value>
-  </data>
-  <data name="ThemeModeSetting_Light" xml:space="preserve">
-    <value>Light</value>
-  </data>
-  <data name="LanguageSetting_Header" xml:space="preserve">
-    <value>Languages</value>
-  </data>
-  <data name="LanguageSetting_Description" xml:space="preserve">
-    <value>Your preferred language is here.</value>
-  </data>
-  <data name="OpenWebsite" xml:space="preserve">
-    <value>Open WebSite</value>
-  </data>
-  <data name="HardwareMonitor_TextBlock" xml:space="preserve">
-    <value>Hardware Monitoring (powered by LibreHardwareMonitor)</value>
-  </data>
-  <data name="CollapseAll" xml:space="preserve">
-    <value>Collapse All</value>
-  </data>
-  <data name="ExpandAll" xml:space="preserve">
-    <value>Expand All</value>
-  </data>
-  <data name="HardwareMonitorInitError" xml:space="preserve">
-    <value>Hardware Monitor Init Error:</value>
-  </data>
-  <data name="ErrorTitle" xml:space="preserve">
-    <value>Error</value>
-  </data>
-  <data name="Welcome" xml:space="preserve">
-    <value>Welcome to SYSTools</value>
-  </data>
-  <data name="News" xml:space="preserve">
-    <value>News</value>
-  </data>
-  <data name="Hello" xml:space="preserve">
-    <value>Hello：</value>
-  </data>
-  <data name="LoadingNews" xml:space="preserve">
-    <value>Loading news...</value>
-  </data>
-  <data name="NetError" xml:space="preserve">
-    <value>Network or website issue detected.</value>
-  </data>
-  <data name="NoticeInfo" xml:space="preserve">
-    <value>No news available.</value>
-  </data>
-  <data name="NoticeError" xml:space="preserve">
-    <value>Unable to retrieve news.</value>
-  </data>
-  <data name="TimeUnitDay" xml:space="preserve">
-    <value>d</value>
-  </data>
-  <data name="TimeUnitHour" xml:space="preserve">
-    <value>h</value>
-  </data>
-  <data name="TimeUnitMinute" xml:space="preserve">
-    <value>m</value>
-  </data>
-  <data name="TimeUnitSecond" xml:space="preserve">
-    <value>s</value>
-  </data>
-  <data name="SystemTime" xml:space="preserve">
-    <value>System Time</value>
-  </data>
-  <data name="SystemStartTime" xml:space="preserve">
-    <value>Up Time</value>
-  </data>
-  <data name="SystemRunTime" xml:space="preserve">
-    <value>Since</value>
-  </data>
-  <data name="CurrentSystem" xml:space="preserve">
-    <value>System Version</value>
-  </data>
-  <data name="UpdateHistory" xml:space="preserve">
-    <value>Windows Update History</value>
-  </data>
-  <data name="UpdateTitle" xml:space="preserve">
-    <value>Update Title</value>
-  </data>
-  <data name="UpdateDate" xml:space="preserve">
-    <value>Date</value>
-  </data>
-  <data name="UpdateStatus" xml:space="preserve">
-    <value>Status</value>
-  </data>
-  <data name="UpdateHistoryError" xml:space="preserve">
-    <value>Error loading update history</value>
-  </data>
-  <data name="UpdateStatusSuccess" xml:space="preserve">
-    <value>Success</value>
-  </data>
-  <data name="UpdateStatusFailed" xml:space="preserve">
-    <value>Failed</value>
-  </data>
-  <data name="UpdateStatusUnknown" xml:space="preserve">
-    <value>Unknown</value>
-  </data>
-  <data name="LoadUpdateHistory" xml:space="preserve">
-    <value>Load Update History</value>
-  </data>
-  <data name="ClearList" xml:space="preserve">
-    <value>Clear List</value>
-  </data>
-  <data name="ServiceProvider" xml:space="preserve">
-    <value>IPv4: ipip.net &amp; IPv6: neu6.edu</value>
-  </data>
-  <data name="IP" xml:space="preserve">
-    <value>Public IP</value>
-  </data>
-  <data name="LR_ToolTip" xml:space="preserve">
-    <value>Left-click to get, right-click to hide.</value>
-  </data>
-  <data name="CustomTool_TextBlock" xml:space="preserve">
-    <value>CustomTool</value>
-  </data>
-  <data name="AddNewTool" xml:space="preserve">
-    <value>Add New Tool</value>
-  </data>
-  <data name="AddCustomTool_TextBlock" xml:space="preserve">
-    <value>Add CustomTool</value>
-  </data>
-  <data name="OK" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="Close" xml:space="preserve">
-    <value>Close</value>
-  </data>
-  <data name="Name" xml:space="preserve">
-    <value>Name:</value>
-  </data>
-  <data name="IconPath" xml:space="preserve">
-    <value>IconPath:</value>
-  </data>
-  <data name="EXEPath" xml:space="preserve">
-    <value>EXEPath:</value>
-  </data>
-  <data name="Args" xml:space="preserve">
-    <value>Args:</value>
-  </data>
-  <data name="CustomIcon" xml:space="preserve">
-    <value>Custom Icon</value>
-  </data>
-  <data name="UseEXEEmbeddedIcon" xml:space="preserve">
-    <value>Use EXE Embedded Icon</value>
-  </data>
-  <data name="Browse" xml:space="preserve">
-    <value>Browse...</value>
-  </data>
-  <data name="Modify" xml:space="preserve">
-    <value>Modify</value>
-  </data>
-  <data name="Delete" xml:space="preserve">
-    <value>Delete</value>
-  </data>
-  <data name="SelectIcon" xml:space="preserve">
-    <value>Select Icon</value>
-  </data>
-  <data name="SelectEXEFile" xml:space="preserve">
-    <value>Select EXE File</value>
-  </data>
-  <data name="ImageFilter" xml:space="preserve">
-    <value>Image File|*.png;*.jpg;*.ico|All File|*.*</value>
-  </data>
-  <data name="EXEFilter" xml:space="preserve">
-    <value>EXE File|*.exe|All File|*.*</value>
-  </data>
-  <data name="Info" xml:space="preserve">
-    <value>Info</value>
-  </data>
-  <data name="NameAndExecutableRequired" xml:space="preserve">
-    <value>Name and executable file are required fields.</value>
-  </data>
-  <data name="Open" xml:space="preserve">
-    <value>Open</value>
-  </data>
-  <data name="ImageFilter_JPng" xml:space="preserve">
-    <value>Image files (*.jpg;*.png)|*.jpg;*.png</value>
-  </data>
-  <data name="ConfirmDeleteMessage" xml:space="preserve">
-    <value>Are you sure you want to delete the tool '{0}' ?</value>
-  </data>
-  <data name="ConfirmModifyMessage" xml:space="preserve">
-    <value>Do you want to modify the tool '{0}' ?</value>
-  </data>
-  <data name="ConfirmDeleteTitle" xml:space="preserve">
-    <value>Confirm Deletion</value>
-  </data>
-  <data name="ConfirmModifyTitle" xml:space="preserve">
-    <value>Confirm Modification</value>
-  </data>
-  <data name="AdministratorMode" xml:space="preserve">
-    <value>[Administrator Mode]</value>
-  </data>
-  <data name="ProcessTotal" xml:space="preserve">
-    <value>A process with the same name is running!</value>
-  </data>
-  <data name="ProcessTotalTitle" xml:space="preserve">
-    <value>Program Conflict!</value>
-  </data>
-  <data name="DetectionTools_Content" xml:space="preserve">
-    <value>Detect Tools</value>
-  </data>
-  <data name="TestTools_Content" xml:space="preserve">
-    <value>Hardware Test Tools</value>
-  </data>
-  <data name="DiskTools_Content" xml:space="preserve">
-    <value>Disk Tools</value>
-  </data>
-  <data name="PeripheralsTools_Content" xml:space="preserve">
-    <value>Peripheral Test Tools</value>
-  </data>
-  <data name="RepairingTools_Content" xml:space="preserve">
-    <value>Runtime Install Tools</value>
-  </data>
-  <data name="AIDA64_Text" xml:space="preserve">
-    <value>AIDA64 offers overclocking support, hardware diagnostics, stress tests, sensor monitoring, and performance benchmarks for CPU, memory, and drives.</value>
-  </data>
-  <data name="CPU-Z_Text" xml:space="preserve">
-    <value>CPU-Z shows processor details—manufacturer, model, architecture, packaging, clock speeds, and max overclock potential.</value>
-  </data>
-  <data name="GPU-Z_Text" xml:space="preserve">
-    <value>GPU-Z is a lightweight tool that reports key information about your graphics card and GPU.</value>
-  </data>
-  <data name="HWiNFO_Text" xml:space="preserve">
-    <value>HWiNFO provides all-in-one hardware analysis and monitoring, from quick overviews to in-depth component data, always up to date.</value>
-  </data>
-  <data name="HWMonitor_Text" xml:space="preserve">
-    <value>HWMonitor reads a PC’s main health sensors—voltages, temperatures, and fan speeds.</value>
-  </data>
-  <data name="Prime95_Text" xml:space="preserve">
-    <value>Prime95 – a dedicated system stability tester. </value>
-  </data>
-  <data name="IntelBurnTest_Text" xml:space="preserve">
-    <value>IntelBurnTest – a Linpack-based stress tool for Intel/AMD CPUs.  </value>
-  </data>
-  <data name="FurMark_Text" xml:space="preserve">
-    <value>FurMark (oZone3D) – an OpenGL fur-rendering benchmark for GPU performance and stability.</value>
-  </data>
-  <data name="MemTest_Text" xml:space="preserve">
-    <value>TechPowerUp MemTest – a memory stability tester.</value>
-  </data>
-  <data name="HKBTest_Text" xml:space="preserve">
-    <value>HKBTest – a keyboard tester for key ghosting detection.</value>
-  </data>
-  <data name="MouseTest_Text" xml:space="preserve">
-    <value>MouseTest – a mouse click-rate tester by MouseHome.</value>
-  </data>
-  <data name="MouseRate_Text" xml:space="preserve">
-    <value>MouseRate – a tool measuring mouse DPI and polling-rate performance.</value>
-  </data>
-  <data name="AS-SSD_Text" xml:space="preserve">
-    <value>AS SSD Benchmark – free SSD tester for sequential/random read &amp; write.</value>
-  </data>
-  <data name="CrystalDiskInfo_Text" xml:space="preserve">
-    <value>CrystalDiskInfo – disk health monitor with drive info, SMART data, and temperature.</value>
-  </data>
-  <data name="CrystalDiskMark_Text" xml:space="preserve">
-    <value>CrystalDiskMark – measures speeds of HDDs, SSDs, and USB drives.</value>
-  </data>
-  <data name="DiskBenchmark_Text" xml:space="preserve">
-    <value>ATTO Disk Benchmark – tests performance of HDDs, SSDs, RAID arrays, and external storage.</value>
-  </data>
-  <data name="DiskGenius_Text" xml:space="preserve">
-    <value>DiskGenius – partition manager and data maintenance tool.</value>
-  </data>
-  <data name="HDTune_Text" xml:space="preserve">
-    <value>HD Tune – all-in-one HDD/SSD utility for benchmarking, error scanning, SMART health, and secure erase.</value>
-  </data>
-  <data name="LLFTOOL_Text" xml:space="preserve">
-    <value>LLFTOOL – simple Windows low-level disk formatter.</value>
-  </data>
-  <data name="PartAssist_Text" xml:space="preserve">
-    <value>AOMEI Partition Assistant – free, professional non-destructive partition manager.</value>
-  </data>
-  <data name="SSD-Z_Text" xml:space="preserve">
-    <value>SSD-Z – reliable SSD info and testing tool.</value>
-  </data>
-  <data name="Victoria_Text" xml:space="preserve">
-    <value>Victoria – Windows disk utility for surface tests, bad-sector repair, SMART/log handling, and cache control.</value>
-  </data>
-  <data name="H2TestW_Text" xml:space="preserve">
-    <value>H2testw – USB drive speed and bad-block tester via write/read verification.</value>
-  </data>
-  <data name="OpenFolder">
-    <value>Open Folder</value>
-  </data>
-  <data name="UncategorizedTools_Content" xml:space="preserve">
-    <value>Uncategorized Tools</value>
-  </data>
-  <data name="SDI_Text" xml:space="preserve">
-    <value>Use this tool to quickly find and install all missing drivers.</value>
-  </data>
-  <data name="Rufus_Text" xml:space="preserve">
-    <value>Lightweight utility to create bootable USB drives from ISO files; supports various OS images and advanced partition schemes.</value>
-  </data>
-  <data name="Etcher_Text" xml:space="preserve">
-    <value>Cross-platform tool for flashing OS images to SD cards or USB drives with a simple, user-friendly interface.</value>
-  </data>
-  <data name="Ventoy_Text" xml:space="preserve">
-    <value>Enables creation of bootable USB drives that can store and boot multiple ISO/WIM/IMG/VHD(x) files without reformatting.</value>
-  </data>
+        </xsd:element>
+    </xsd:schema>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>2.0</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="ContactUs" xml:space="preserve">
+        <value>Contact Us</value>
+    </data>
+    <data name="QQGroup" xml:space="preserve">
+        <value>QQ Group</value>
+    </data>
+    <data name="WebSite" xml:space="preserve">
+        <value>Website</value>
+    </data>
+    <data name="GithubRepo" xml:space="preserve">
+        <value>Github Repository</value>
+    </data>
+    <data name="Developers" xml:space="preserve">
+        <value>Developers &amp; Designers &amp; External Contributors</value>
+    </data>
+    <data name="ComponentsLicense" xml:space="preserve">
+        <value>Third-Party Libraries</value>
+    </data>
+    <data name="SYSToolsUpdate" xml:space="preserve">
+        <value>Update</value>
+    </data>
+    <data name="SoftwareToolkitUpdate" xml:space="preserve">
+        <value>Software &amp; Toolkit Update</value>
+    </data>
+    <data name="SoftwareUpdate" xml:space="preserve">
+        <value>Software Update</value>
+    </data>
+    <data name="ToolkitUpdate" xml:space="preserve">
+        <value>Toolkit Update</value>
+    </data>
+    <data name="PolicyAgreement" xml:space="preserve">
+        <value>Privacy Policy &amp; User Agreement</value>
+    </data>
+    <data name="PrivacyPolicy" xml:space="preserve">
+        <value>Privacy Policy</value>
+    </data>
+    <data name="UserAgreement" xml:space="preserve">
+        <value>User Agreement</value>
+    </data>
+    <data name="BackImageSetting_Description" xml:space="preserve">
+        <value>Preview and set the background image, blur, and opacity.</value>
+    </data>
+    <data name="BackImageSetting_Header" xml:space="preserve">
+        <value>Background &amp; Effects</value>
+    </data>
+    <data name="BackImagePreview" xml:space="preserve">
+        <value>Preview your background image</value>
+    </data>
+    <data name="SelectBackgroundImage" xml:space="preserve">
+        <value>Select</value>
+    </data>
+    <data name="ClearBackgroundImage" xml:space="preserve">
+        <value>Clear</value>
+    </data>
+    <data name="BackgroundImageBlurRadius_Description" xml:space="preserve">
+        <value>High blur settings may cause lag.</value>
+    </data>
+    <data name="BackgroundImageBlurRadius_Header" xml:space="preserve">
+        <value>Image Blur Effect (Experimental)</value>
+    </data>
+    <data name="BackgroundImageOpacity_Header" xml:space="preserve">
+        <value>Image Opacity (Experimental)</value>
+    </data>
+    <data name="ProgramThemeSetting_Header" xml:space="preserve">
+        <value>Themes</value>
+    </data>
+    <data name="ProgramThemeSetting_Description" xml:space="preserve">
+        <value>Choose a light/dark theme.</value>
+    </data>
+    <data name="ThemeModeSetting_Auto" xml:space="preserve">
+        <value>Auto</value>
+    </data>
+    <data name="ThemeModeSetting_Dark" xml:space="preserve">
+        <value>Dark</value>
+    </data>
+    <data name="ThemeModeSetting_Light" xml:space="preserve">
+        <value>Light</value>
+    </data>
+    <data name="LanguageSetting_Header" xml:space="preserve">
+        <value>Languages</value>
+    </data>
+    <data name="LanguageSetting_Description" xml:space="preserve">
+        <value>Your preferred language is here.</value>
+    </data>
+    <data name="OpenWebsite" xml:space="preserve">
+        <value>Open WebSite</value>
+    </data>
+    <data name="HardwareMonitor_TextBlock" xml:space="preserve">
+        <value>Hardware Monitoring (powered by LibreHardwareMonitor)</value>
+    </data>
+    <data name="CollapseAll" xml:space="preserve">
+        <value>Collapse All</value>
+    </data>
+    <data name="ExpandAll" xml:space="preserve">
+        <value>Expand All</value>
+    </data>
+    <data name="HardwareMonitorInitError" xml:space="preserve">
+        <value>Hardware Monitor Init Error:</value>
+    </data>
+    <data name="ErrorTitle" xml:space="preserve">
+        <value>Error</value>
+    </data>
+    <data name="Welcome" xml:space="preserve">
+        <value>Welcome to SYSTools</value>
+    </data>
+    <data name="News" xml:space="preserve">
+        <value>News</value>
+    </data>
+    <data name="Hello" xml:space="preserve">
+        <value>Hello：</value>
+    </data>
+    <data name="LoadingNews" xml:space="preserve">
+        <value>Loading news...</value>
+    </data>
+    <data name="NetError" xml:space="preserve">
+        <value>Network or website issue detected.</value>
+    </data>
+    <data name="NoticeInfo" xml:space="preserve">
+        <value>No news available.</value>
+    </data>
+    <data name="NoticeError" xml:space="preserve">
+        <value>Unable to retrieve news.</value>
+    </data>
+    <data name="TimeUnitDay" xml:space="preserve">
+        <value>d</value>
+    </data>
+    <data name="TimeUnitHour" xml:space="preserve">
+        <value>h</value>
+    </data>
+    <data name="TimeUnitMinute" xml:space="preserve">
+        <value>m</value>
+    </data>
+    <data name="TimeUnitSecond" xml:space="preserve">
+        <value>s</value>
+    </data>
+    <data name="SystemTime" xml:space="preserve">
+        <value>System Time</value>
+    </data>
+    <data name="SystemStartTime" xml:space="preserve">
+        <value>Up Time</value>
+    </data>
+    <data name="SystemRunTime" xml:space="preserve">
+        <value>Since</value>
+    </data>
+    <data name="CurrentSystem" xml:space="preserve">
+        <value>System Version</value>
+    </data>
+    <data name="UpdateHistory" xml:space="preserve">
+        <value>Windows Update History</value>
+    </data>
+    <data name="UpdateTitle" xml:space="preserve">
+        <value>Update Title</value>
+    </data>
+    <data name="UpdateDate" xml:space="preserve">
+        <value>Date</value>
+    </data>
+    <data name="UpdateStatus" xml:space="preserve">
+        <value>Status</value>
+    </data>
+    <data name="UpdateHistoryError" xml:space="preserve">
+        <value>Error loading update history</value>
+    </data>
+    <data name="UpdateStatusSuccess" xml:space="preserve">
+        <value>Success</value>
+    </data>
+    <data name="UpdateStatusFailed" xml:space="preserve">
+        <value>Failed</value>
+    </data>
+    <data name="UpdateStatusUnknown" xml:space="preserve">
+        <value>Unknown</value>
+    </data>
+    <data name="LoadUpdateHistory" xml:space="preserve">
+        <value>Load Update History</value>
+    </data>
+    <data name="ClearList" xml:space="preserve">
+        <value>Clear List</value>
+    </data>
+    <data name="ServiceProvider" xml:space="preserve">
+        <value>IPv4: ipip.net &amp; IPv6: neu6.edu</value>
+    </data>
+    <data name="IP" xml:space="preserve">
+        <value>Public IP</value>
+    </data>
+    <data name="LR_ToolTip" xml:space="preserve">
+        <value>Left-click to get, right-click to hide.</value>
+    </data>
+    <data name="CustomTool_TextBlock" xml:space="preserve">
+        <value>CustomTool</value>
+    </data>
+    <data name="AddNewTool" xml:space="preserve">
+        <value>Add New Tool</value>
+    </data>
+    <data name="AddCustomTool_TextBlock" xml:space="preserve">
+        <value>Add CustomTool</value>
+    </data>
+    <data name="OK" xml:space="preserve">
+        <value>OK</value>
+    </data>
+    <data name="Close" xml:space="preserve">
+        <value>Close</value>
+    </data>
+    <data name="Name" xml:space="preserve">
+        <value>Name:</value>
+    </data>
+    <data name="IconPath" xml:space="preserve">
+        <value>IconPath:</value>
+    </data>
+    <data name="EXEPath" xml:space="preserve">
+        <value>EXEPath:</value>
+    </data>
+    <data name="Args" xml:space="preserve">
+        <value>Args:</value>
+    </data>
+    <data name="CustomIcon" xml:space="preserve">
+        <value>Custom Icon</value>
+    </data>
+    <data name="UseEXEEmbeddedIcon" xml:space="preserve">
+        <value>Use EXE Embedded Icon</value>
+    </data>
+    <data name="Browse" xml:space="preserve">
+        <value>Browse...</value>
+    </data>
+    <data name="Modify" xml:space="preserve">
+        <value>Modify</value>
+    </data>
+    <data name="Delete" xml:space="preserve">
+        <value>Delete</value>
+    </data>
+    <data name="SelectIcon" xml:space="preserve">
+        <value>Select Icon</value>
+    </data>
+    <data name="SelectEXEFile" xml:space="preserve">
+        <value>Select EXE File</value>
+    </data>
+    <data name="ImageFilter" xml:space="preserve">
+        <value>Image File|*.png;*.jpg;*.ico|All File|*.*</value>
+    </data>
+    <data name="EXEFilter" xml:space="preserve">
+        <value>EXE File|*.exe|All File|*.*</value>
+    </data>
+    <data name="Info" xml:space="preserve">
+        <value>Info</value>
+    </data>
+    <data name="NameAndExecutableRequired" xml:space="preserve">
+        <value>Name and executable file are required fields.</value>
+    </data>
+    <data name="Open" xml:space="preserve">
+        <value>Open</value>
+    </data>
+    <data name="ImageFilter_JPng" xml:space="preserve">
+        <value>Image files (*.jpg;*.png)|*.jpg;*.png</value>
+    </data>
+    <data name="ConfirmDeleteMessage" xml:space="preserve">
+        <value>Are you sure you want to delete the tool '{0}' ?</value>
+    </data>
+    <data name="ConfirmModifyMessage" xml:space="preserve">
+        <value>Do you want to modify the tool '{0}' ?</value>
+    </data>
+    <data name="ConfirmDeleteTitle" xml:space="preserve">
+        <value>Confirm Deletion</value>
+    </data>
+    <data name="ConfirmModifyTitle" xml:space="preserve">
+        <value>Confirm Modification</value>
+    </data>
+    <data name="AdministratorMode" xml:space="preserve">
+        <value>[Administrator Mode]</value>
+    </data>
+    <data name="ProcessTotal" xml:space="preserve">
+        <value>A process with the same name is running!</value>
+    </data>
+    <data name="ProcessTotalTitle" xml:space="preserve">
+        <value>Program Conflict!</value>
+    </data>
+    <data name="DetectionTools_Content" xml:space="preserve">
+        <value>Detect Tools</value>
+    </data>
+    <data name="TestTools_Content" xml:space="preserve">
+        <value>Hardware Test Tools</value>
+    </data>
+    <data name="DiskTools_Content" xml:space="preserve">
+        <value>Disk Tools</value>
+    </data>
+    <data name="PeripheralsTools_Content" xml:space="preserve">
+        <value>Peripheral Test Tools</value>
+    </data>
+    <data name="RepairingTools_Content" xml:space="preserve">
+        <value>Runtime Install Tools</value>
+    </data>
+    <data name="AIDA64_Text" xml:space="preserve">
+        <value>AIDA64 offers overclocking support, hardware diagnostics, stress tests, sensor monitoring, and performance benchmarks for CPU, memory, and drives.</value>
+    </data>
+    <data name="CPU-Z_Text" xml:space="preserve">
+        <value>CPU-Z shows processor details—manufacturer, model, architecture, packaging, clock speeds, and max overclock potential.</value>
+    </data>
+    <data name="GPU-Z_Text" xml:space="preserve">
+        <value>GPU-Z is a lightweight tool that reports key information about your graphics card and GPU.</value>
+    </data>
+    <data name="HWiNFO_Text" xml:space="preserve">
+        <value>HWiNFO provides all-in-one hardware analysis and monitoring, from quick overviews to in-depth component data, always up to date.</value>
+    </data>
+    <data name="HWMonitor_Text" xml:space="preserve">
+        <value>HWMonitor reads a PC’s main health sensors—voltages, temperatures, and fan speeds.</value>
+    </data>
+    <data name="Prime95_Text" xml:space="preserve">
+        <value>Prime95 – a dedicated system stability tester. </value>
+    </data>
+    <data name="IntelBurnTest_Text" xml:space="preserve">
+        <value>IntelBurnTest – a Linpack-based stress tool for Intel/AMD CPUs.  </value>
+    </data>
+    <data name="FurMark_Text" xml:space="preserve">
+        <value>FurMark (oZone3D) – an OpenGL fur-rendering benchmark for GPU performance and stability.</value>
+    </data>
+    <data name="MemTest_Text" xml:space="preserve">
+        <value>TechPowerUp MemTest – a memory stability tester.</value>
+    </data>
+    <data name="HKBTest_Text" xml:space="preserve">
+        <value>HKBTest – a keyboard tester for key ghosting detection.</value>
+    </data>
+    <data name="MouseTest_Text" xml:space="preserve">
+        <value>MouseTest – a mouse click-rate tester by MouseHome.</value>
+    </data>
+    <data name="MouseRate_Text" xml:space="preserve">
+        <value>MouseRate – a tool measuring mouse DPI and polling-rate performance.</value>
+    </data>
+    <data name="AS-SSD_Text" xml:space="preserve">
+        <value>AS SSD Benchmark – free SSD tester for sequential/random read &amp; write.</value>
+    </data>
+    <data name="CrystalDiskInfo_Text" xml:space="preserve">
+        <value>CrystalDiskInfo – disk health monitor with drive info, SMART data, and temperature.</value>
+    </data>
+    <data name="CrystalDiskMark_Text" xml:space="preserve">
+        <value>CrystalDiskMark – measures speeds of HDDs, SSDs, and USB drives.</value>
+    </data>
+    <data name="DiskBenchmark_Text" xml:space="preserve">
+        <value>ATTO Disk Benchmark – tests performance of HDDs, SSDs, RAID arrays, and external storage.</value>
+    </data>
+    <data name="DiskGenius_Text" xml:space="preserve">
+        <value>DiskGenius – partition manager and data maintenance tool.</value>
+    </data>
+    <data name="HDTune_Text" xml:space="preserve">
+        <value>HD Tune – all-in-one HDD/SSD utility for benchmarking, error scanning, SMART health, and secure erase.</value>
+    </data>
+    <data name="LLFTOOL_Text" xml:space="preserve">
+        <value>LLFTOOL – simple Windows low-level disk formatter.</value>
+    </data>
+    <data name="PartAssist_Text" xml:space="preserve">
+        <value>AOMEI Partition Assistant – free, professional non-destructive partition manager.</value>
+    </data>
+    <data name="SSD-Z_Text" xml:space="preserve">
+        <value>SSD-Z – reliable SSD info and testing tool.</value>
+    </data>
+    <data name="Victoria_Text" xml:space="preserve">
+        <value>Victoria – Windows disk utility for surface tests, bad-sector repair, SMART/log handling, and cache control.</value>
+    </data>
+    <data name="H2TestW_Text" xml:space="preserve">
+        <value>H2testw – USB drive speed and bad-block tester via write/read verification.</value>
+    </data>
+    <data name="OpenFolder">
+        <value>Open Folder</value>
+    </data>
+    <data name="UncategorizedTools_Content" xml:space="preserve">
+        <value>Uncategorized Tools</value>
+    </data>
+    <data name="SDI_Text" xml:space="preserve">
+        <value>Use this tool to quickly find and install all missing drivers.</value>
+    </data>
+    <data name="Rufus_Text" xml:space="preserve">
+        <value>Lightweight utility to create bootable USB drives from ISO files; supports various OS images and advanced partition schemes.</value>
+    </data>
+    <data name="Etcher_Text" xml:space="preserve">
+        <value>Cross-platform tool for flashing OS images to SD cards or USB drives with a simple, user-friendly interface.</value>
+    </data>
+    <data name="Ventoy_Text" xml:space="preserve">
+        <value>Enables creation of bootable USB drives that can store and boot multiple ISO/WIM/IMG/VHD(x) files without reformatting.</value>
+    </data>
+    <data name="Version" xml:space="preserve">
+        <value>Version</value>
+    </data>
+    <data name="Memory" xml:space="preserve">
+        <value>Memory</value>
+    </data>
+    <data name="Disk" xml:space="preserve">
+        <value>Disk</value>
+    </data>
+    <data name="SystemResources" xml:space="preserve">
+        <value>System Resources</value>
+    </data>
+    <data name="SystemHealth" xml:space="preserve">
+        <value>System Health</value>
+    </data>
+    <data name="SystemHealthGood" xml:space="preserve">
+        <value>Good</value>
+    </data>
+    <data name="SystemHealthWarning" xml:space="preserve">
+        <value>Warning</value>
+    </data>
+    <data name="SystemHealthCritical" xml:space="preserve">
+        <value>Critical</value>
+    </data>
+    <data name="QuickActions" xml:space="preserve">
+        <value>Quick Actions</value>
+    </data>
+    <data name="Weather" xml:space="preserve">
+        <value>Weather</value>
+    </data>
+    <data name="LoadingWeather" xml:space="preserve">
+        <value>Loading...</value>
+    </data>
+    <data name="WeatherNotConfigured" xml:space="preserve">
+        <value>Weather service not configured</value>
+    </data>
+    <data name="Hitokoto" xml:space="preserve">
+        <value>Hitokoto</value>
+    </data>
+    <data name="LoadingHitokoto" xml:space="preserve">
+        <value>Loading...</value>
+    </data>
+    <data name="Loading" xml:space="preserve">
+        <value>Loading...</value>
+    </data>
+    <data name="IPv4Error" xml:space="preserve">
+        <value>No IPv4 address available or failed to retrieve</value>
+    </data>
+    <data name="IPv6Error" xml:space="preserve">
+        <value>No IPv6 address available or failed to retrieve</value>
+    </data>
+    <data name="ConfirmAction" xml:space="preserve">
+        <value>Confirm this action?</value>
+    </data>
+    <data name="Confirmation" xml:space="preserve">
+        <value>Confirmation</value>
+    </data>
+    <data name="ExecutionError" xml:space="preserve">
+        <value>Execution failed</value>
+    </data>
+    <data name="Error" xml:space="preserve">
+        <value>Error</value>
+    </data>
 </root>

--- a/SYSTools/Properties/Lang.zh-Hans.resx
+++ b/SYSTools/Properties/Lang.zh-Hans.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+    <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,437 +59,500 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+        <xsd:element name="root" msdata:IsDataSet="true">
             <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
+                <xsd:choice maxOccurs="unbounded">
+                    <xsd:element name="metadata">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" use="required" type="xsd:string" />
+                            <xsd:attribute name="type" type="xsd:string" />
+                            <xsd:attribute name="mimetype" type="xsd:string" />
+                            <xsd:attribute ref="xml:space" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="assembly">
+                        <xsd:complexType>
+                            <xsd:attribute name="alias" type="xsd:string" />
+                            <xsd:attribute name="name" type="xsd:string" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="data">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+                            <xsd:attribute ref="xml:space" />
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="resheader">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                            </xsd:sequence>
+                            <xsd:attribute name="name" type="xsd:string" use="required" />
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
             </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
-  <resheader name="resmimetype">
-    <value>text/microsoft-resx</value>
-  </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
-  <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <data name="ContactUs" xml:space="preserve">
-    <value>联系我们</value>
-  </data>
-  <data name="QQGroup" xml:space="preserve">
-    <value>QQ群</value>
-  </data>
-  <data name="WebSite" xml:space="preserve">
-    <value>官网</value>
-  </data>
-  <data name="GithubRepo" xml:space="preserve">
-    <value>Github仓库</value>
-  </data>
-  <data name="Developers" xml:space="preserve">
-    <value>开发人员 ＆ 设计人员 ＆ 外部支援</value>
-  </data>
-  <data name="ComponentsLicense" xml:space="preserve">
-    <value>软件中使用的组件及对应仓库</value>
-  </data>
-  <data name="SYSToolsUpdate" xml:space="preserve">
-    <value>SYSTools更新</value>
-  </data>
-  <data name="SoftwareToolkitUpdate" xml:space="preserve">
-    <value>软件更新 ＆ 工具包更新</value>
-  </data>
-  <data name="SoftwareUpdate" xml:space="preserve">
-    <value>软件更新</value>
-  </data>
-  <data name="ToolkitUpdate" xml:space="preserve">
-    <value>工具包更新</value>
-  </data>
-  <data name="PolicyAgreement" xml:space="preserve">
-    <value>隐私协议 ＆ 用户协议</value>
-  </data>
-  <data name="PrivacyPolicy" xml:space="preserve">
-    <value>隐私协议</value>
-  </data>
-  <data name="UserAgreement" xml:space="preserve">
-    <value>用户协议</value>
-  </data>
-  <data name="BackImageSetting_Description" xml:space="preserve">
-    <value>预览/设置 图片＆模糊度＆透明度</value>
-  </data>
-  <data name="BackImageSetting_Header" xml:space="preserve">
-    <value>背景图片设置</value>
-  </data>
-  <data name="BackImagePreview" xml:space="preserve">
-    <value>背景图片预览</value>
-  </data>
-  <data name="SelectBackgroundImage" xml:space="preserve">
-    <value>选择背景图片</value>
-  </data>
-  <data name="ClearBackgroundImage" xml:space="preserve">
-    <value>清空背景图片</value>
-  </data>
-  <data name="BackgroundImageBlurRadius_Description" xml:space="preserve">
-    <value>模糊效果过高容易导致卡顿</value>
-  </data>
-  <data name="BackgroundImageBlurRadius_Header" xml:space="preserve">
-    <value>图片模糊效果(实验性)</value>
-  </data>
-  <data name="BackgroundImageOpacity_Header" xml:space="preserve">
-    <value>图片不透明度(实验性)</value>
-  </data>
-  <data name="ProgramThemeSetting_Header" xml:space="preserve">
-    <value>程序主题设定</value>
-  </data>
-  <data name="ProgramThemeSetting_Description" xml:space="preserve">
-    <value>设定程序的主题风格为深/浅色模式</value>
-  </data>
-  <data name="ThemeModeSetting_Auto" xml:space="preserve">
-    <value>跟随系统</value>
-  </data>
-  <data name="ThemeModeSetting_Dark" xml:space="preserve">
-    <value>深色</value>
-  </data>
-  <data name="ThemeModeSetting_Light" xml:space="preserve">
-    <value>浅色</value>
-  </data>
-  <data name="LanguageSetting_Header" xml:space="preserve">
-    <value>语言设定</value>
-  </data>
-  <data name="LanguageSetting_Description" xml:space="preserve">
-    <value>设定程序显示的语言</value>
-  </data>
-  <data name="OpenWebsite" xml:space="preserve">
-    <value>打开网页</value>
-  </data>
-  <data name="HardwareMonitor_TextBlock" xml:space="preserve">
-    <value>传感器信息收集 ( 基于 LibreHardwareMonitor ) 信息仅供参考</value>
-  </data>
-  <data name="CollapseAll" xml:space="preserve">
-    <value>全部收起</value>
-  </data>
-  <data name="ExpandAll" xml:space="preserve">
-    <value>全部展开</value>
-  </data>
-  <data name="ErrorTitle" xml:space="preserve">
-    <value>错误</value>
-  </data>
-  <data name="HardwareMonitorInitError" xml:space="preserve">
-    <value>初始化硬件监控时出错:</value>
-  </data>
-  <data name="Welcome" xml:space="preserve">
-    <value>欢迎使用SYSTools工具箱</value>
-  </data>
-  <data name="News" xml:space="preserve">
-    <value>公告</value>
-  </data>
-  <data name="Hello" xml:space="preserve">
-    <value>您好：</value>
-  </data>
-  <data name="LoadingNews" xml:space="preserve">
-    <value>正在加载公告...</value>
-  </data>
-  <data name="NetError" xml:space="preserve">
-    <value>网络或网站出现问题</value>
-  </data>
-  <data name="NoticeInfo" xml:space="preserve">
-    <value>暂无公告</value>
-  </data>
-  <data name="NoticeError" xml:space="preserve">
-    <value>无法获取公告</value>
-  </data>
-  <data name="TimeUnitDay" xml:space="preserve">
-    <value>天</value>
-  </data>
-  <data name="TimeUnitHour" xml:space="preserve">
-    <value>时</value>
-  </data>
-  <data name="TimeUnitMinute" xml:space="preserve">
-    <value>分</value>
-  </data>
-  <data name="TimeUnitSecond" xml:space="preserve">
-    <value>秒</value>
-  </data>
-  <data name="SystemTime" xml:space="preserve">
-    <value>系统时间</value>
-  </data>
-  <data name="SystemStartTime" xml:space="preserve">
-    <value>启动日期</value>
-  </data>
-  <data name="SystemRunTime" xml:space="preserve">
-    <value>运行时间</value>
-  </data>
-  <data name="CurrentSystem" xml:space="preserve">
-    <value>系统版本</value>
-  </data>
-  <data name="UpdateHistory" xml:space="preserve">
-    <value>Windows 更新历史记录</value>
-  </data>
-  <data name="UpdateTitle" xml:space="preserve">
-    <value>更新标题</value>
-  </data>
-  <data name="UpdateDate" xml:space="preserve">
-    <value>日期</value>
-  </data>
-  <data name="UpdateStatus" xml:space="preserve">
-    <value>状态</value>
-  </data>
-  <data name="UpdateHistoryError" xml:space="preserve">
-    <value>加载更新历史记录失败</value>
-  </data>
-  <data name="UpdateStatusSuccess" xml:space="preserve">
-    <value>成功</value>
-  </data>
-  <data name="UpdateStatusFailed" xml:space="preserve">
-    <value>失败</value>
-  </data>
-  <data name="UpdateStatusUnknown" xml:space="preserve">
-    <value>未知</value>
-  </data>
-  <data name="LoadUpdateHistory" xml:space="preserve">
-    <value>加载更新历史</value>
-  </data>
-  <data name="ClearList" xml:space="preserve">
-    <value>清空列表</value>
-  </data>
-  <data name="ServiceProvider" xml:space="preserve">
-    <value>IPv4: ipip.net &amp; IPv6: neu6.edu</value>
-  </data>
-  <data name="IP" xml:space="preserve">
-    <value>公网IP</value>
-  </data>
-  <data name="LR_ToolTip" xml:space="preserve">
-    <value>左键单击获取 右键单击隐藏</value>
-  </data>
-  <data name="CustomTool_TextBlock" xml:space="preserve">
-    <value>自定义工具</value>
-  </data>
-  <data name="AddNewTool" xml:space="preserve">
-    <value>添加新工具</value>
-  </data>
-  <data name="AddCustomTool_TextBlock" xml:space="preserve">
-    <value>添加自定义工具</value>
-  </data>
-  <data name="OK" xml:space="preserve">
-    <value>确定</value>
-  </data>
-  <data name="Close" xml:space="preserve">
-    <value>取消</value>
-  </data>
-  <data name="Name" xml:space="preserve">
-    <value>名称:</value>
-  </data>
-  <data name="IconPath" xml:space="preserve">
-    <value>图标路径:</value>
-  </data>
-  <data name="EXEPath" xml:space="preserve">
-    <value>可执行文件:</value>
-  </data>
-  <data name="Args" xml:space="preserve">
-    <value>参数:</value>
-  </data>
-  <data name="CustomIcon" xml:space="preserve">
-    <value>自定义图标</value>
-  </data>
-  <data name="UseEXEEmbeddedIcon" xml:space="preserve">
-    <value>使用 exe 内嵌图标</value>
-  </data>
-  <data name="Browse" xml:space="preserve">
-    <value>浏览...</value>
-  </data>
-  <data name="Modify" xml:space="preserve">
-    <value>修改</value>
-  </data>
-  <data name="Delete" xml:space="preserve">
-    <value>删除</value>
-  </data>
-  <data name="SelectIcon" xml:space="preserve">
-    <value>选择图标</value>
-  </data>
-  <data name="SelectEXEFile" xml:space="preserve">
-    <value>选择可执行文件</value>
-  </data>
-  <data name="ImageFilter" xml:space="preserve">
-    <value>图像文件|*.png;*.jpg;*.ico|所有文件|*.*</value>
-  </data>
-  <data name="EXEFilter" xml:space="preserve">
-    <value>可执行文件|*.exe|所有文件|*.*</value>
-  </data>
-  <data name="Info" xml:space="preserve">
-    <value>提示</value>
-  </data>
-  <data name="NameAndExecutableRequired" xml:space="preserve">
-    <value>名称和可执行文件为必填项.</value>
-  </data>
-  <data name="Open" xml:space="preserve">
-    <value>启动</value>
-  </data>
-  <data name="ImageFilter_JPng" xml:space="preserve">
-    <value>图像文件 (*.jpg;*.png)|*.jpg;*.png</value>
-  </data>
-  <data name="ConfirmDeleteMessage" xml:space="preserve">
-    <value>确定要删除工具 '{0}' 吗？</value>
-  </data>
-  <data name="ConfirmModifyMessage" xml:space="preserve">
-    <value>是否要修改工具 '{0}' ？</value>
-  </data>
-  <data name="ConfirmDeleteTitle" xml:space="preserve">
-    <value>确认删除</value>
-  </data>
-  <data name="ConfirmModifyTitle" xml:space="preserve">
-    <value>确认修改</value>
-  </data>
-  <data name="AdministratorMode" xml:space="preserve">
-    <value>[管理员模式]</value>
-  </data>
-  <data name="ProcessTotal" xml:space="preserve">
-    <value>有一个同名进程正在运行！</value>
-  </data>
-  <data name="ProcessTotalTitle" xml:space="preserve">
-    <value>程序冲突！</value>
-  </data>
-  <data name="DetectionTools_Content" xml:space="preserve">
-    <value>检测工具</value>
-  </data>
-  <data name="TestTools_Content" xml:space="preserve">
-    <value>硬件测试工具</value>
-  </data>
-  <data name="DiskTools_Content" xml:space="preserve">
-    <value>硬盘工具</value>
-  </data>
-  <data name="PeripheralsTools_Content" xml:space="preserve">
-    <value>外设检测工具</value>
-  </data>
-  <data name="RepairingTools_Content" xml:space="preserve">
-    <value>运行库安装工具</value>
-  </data>
-  <data name="AIDA64_Text" xml:space="preserve">
-    <value>AIDA64提供了诸如协助超频，硬件侦错，压力测试和传感器监测等多种功能，而且还可以对处理器，系统内存和磁盘驱动器的性能进行全面评估。</value>
-  </data>
-  <data name="CPU-Z_Text" xml:space="preserve">
-    <value>CPU-Z提供一些关于处理器的信息，包含了制造厂及处理器名称，核心构造及封装技术，内部、外部频率，最大超频速度检测。</value>
-  </data>
-  <data name="GPU-Z_Text" xml:space="preserve">
-    <value>GPU-Z 是一个轻量级的系统实用程序，旨在提供有关您的显卡和图形处理器的重要信息。</value>
-  </data>
-  <data name="HWiNFO_Text" xml:space="preserve">
-    <value>HWiNFO 是一种用于硬件分析和监控的一体化解决方案，从快速概览展开到所有硬件组件的深度。始终保持最新状态，支持最新的技术和标准。</value>
-  </data>
-  <data name="HWMonitor_Text" xml:space="preserve">
-    <value>HWMonitor是一个硬件监控程序，它读取 PC 系统的主要健康传感器：电压、温度、风扇速度。</value>
-  </data>
-  <data name="Prime95_Text" xml:space="preserve">
-    <value>Prime95是一个专用测试系统稳定的软件。</value>
-  </data>
-  <data name="IntelBurnTest_Text" xml:space="preserve">
-    <value>IntelBurnTest是一款Intel/AMD处理器稳定性强力测试工具，简化了使用英特尔Linpack。</value>
-  </data>
-  <data name="FurMark_Text" xml:space="preserve">
-    <value>FurMark是oZone3D开发的一款OpenGL基准测试工具，通过皮毛渲染算法来衡量显卡的性能，同时还能借此考验显卡的稳定性。</value>
-  </data>
-  <data name="MemTest_Text" xml:space="preserve">
-    <value>TechPowerUp出品的MemTest内存稳定性测试工具。</value>
-  </data>
-  <data name="HKBTest_Text" xml:space="preserve">
-    <value>HKBTest是一款键盘测试工具，可以用于键盘按键冲突检测。</value>
-  </data>
-  <data name="MouseTest_Text" xml:space="preserve">
-    <value>MouseTest是鼠标之家出品的鼠标按键连点检测工具</value>
-  </data>
-  <data name="MouseRate_Text" xml:space="preserve">
-    <value>MouseRate是一款检测鼠标DPI和扫描率综合性能的软件</value>
-  </data>
-  <data name="AS-SSD_Text" xml:space="preserve">
-    <value>AS SSD Benchmark是一款功能强大、免费实用的硬盘性能测试工具,软件能够帮助用户测出固态硬盘持续读写等的性能。</value>
-  </data>
-  <data name="CrystalDiskInfo_Text" xml:space="preserve">
-    <value>CrystalDiskInfo是一个硬盘健康监测工具。它显示了硬盘驱动器的基本信息，智能监控和磁盘的温度。可以迅速读到本机硬盘的详细信息。</value>
-  </data>
-  <data name="CrystalDiskMark_Text" xml:space="preserve">
-    <value>CrystalDiskMark是一个衡量各种存储（HDD、SSD、USB 内存等）速度的基准软件。</value>
-  </data>
-  <data name="DiskBenchmark_Text" xml:space="preserve">
-    <value>ATTO Disk Benchmark 可以测量硬盘驱动器、固态驱动器、RAID 阵列以及主机连接到附加存储的性能。</value>
-  </data>
-  <data name="DiskGenius_Text" xml:space="preserve">
-    <value>DiskGenius是一款硬盘分区及数据维护软件。</value>
-  </data>
-  <data name="HDTune_Text" xml:space="preserve">
-    <value>HD Tune是一款具有多种功能的硬盘/SSD 实用程序。它可用于测量驱动器的性能、扫描错误、检查健康状态 (SMART)、安全擦除所有数据等等。</value>
-  </data>
-  <data name="LLFTOOL_Text" xml:space="preserve">
-    <value>LLFTOOL万能低格工具是一款适用于windows操作系统的硬盘低级格式化工具，该硬盘低格工具使用方便，操作简单。</value>
-  </data>
-  <data name="PartAssist_Text" xml:space="preserve">
-    <value>傲梅分区助手是一款免费、专业级的无损分区工具，提供简单、易用的磁盘分区管理操作。</value>
-  </data>
-  <data name="SSD-Z_Text" xml:space="preserve">
-    <value>SSD-Z是一款针对SSD设备的高可靠性的测试软件。</value>
-  </data>
-  <data name="Victoria_Text" xml:space="preserve">
-    <value>Victoria是Windows环境下强大的硬盘维护工具，具备硬盘表面检测/硬盘坏道修复/S.M.A.R.T.信息察看保存/Cache缓存控制等多功能的工具。</value>
-  </data>
-  <data name="H2TestW_Text" xml:space="preserve">
-    <value>H2testw是一款u盘读写速度测试和坏块检测软件，通过往待测目录写入数据的方式测试u盘的实际写入速度校验写入的数据是否正确。</value>
-  </data>
-  <data name="OpenFolder" xml:space="preserve">
-    <value>打开目录</value>
-  </data>
-  <data name="UncategorizedTools_Content" xml:space="preserve">
-    <value>未分类工具</value>
-  </data>
-  <data name="SDI_Text" xml:space="preserve">
-    <value>使用该工具可快速查找并安装所有丢失的驱动程序。</value>
-  </data>
-  <data name="Rufus_Text" xml:space="preserve">
-    <value>轻量级工具，用于从ISO文件创建可启动USB驱动器；支持多种操作系统镜像和高级分区方案。</value>
-  </data>
-  <data name="Etcher_Text" xml:space="preserve">
-    <value>跨平台工具，用于将操作系统镜像刷写到SD卡或USB驱动器，配备简单易用的用户界面。</value>
-  </data>
-  <data name="Ventoy_Text" xml:space="preserve">
-    <value>支持创建可启动的USB驱动器，该驱动器可存储并启动多个ISO/WIM/IMG/VHD(x)文件，且无需重新格式化。</value>
-  </data>
+        </xsd:element>
+    </xsd:schema>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>2.0</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="ContactUs" xml:space="preserve">
+        <value>联系我们</value>
+    </data>
+    <data name="QQGroup" xml:space="preserve">
+        <value>QQ群</value>
+    </data>
+    <data name="WebSite" xml:space="preserve">
+        <value>官网</value>
+    </data>
+    <data name="GithubRepo" xml:space="preserve">
+        <value>Github仓库</value>
+    </data>
+    <data name="Developers" xml:space="preserve">
+        <value>开发人员 ＆ 设计人员 ＆ 外部支援</value>
+    </data>
+    <data name="ComponentsLicense" xml:space="preserve">
+        <value>软件中使用的组件及对应仓库</value>
+    </data>
+    <data name="SYSToolsUpdate" xml:space="preserve">
+        <value>SYSTools更新</value>
+    </data>
+    <data name="SoftwareToolkitUpdate" xml:space="preserve">
+        <value>软件更新 ＆ 工具包更新</value>
+    </data>
+    <data name="SoftwareUpdate" xml:space="preserve">
+        <value>软件更新</value>
+    </data>
+    <data name="ToolkitUpdate" xml:space="preserve">
+        <value>工具包更新</value>
+    </data>
+    <data name="PolicyAgreement" xml:space="preserve">
+        <value>隐私协议 ＆ 用户协议</value>
+    </data>
+    <data name="PrivacyPolicy" xml:space="preserve">
+        <value>隐私协议</value>
+    </data>
+    <data name="UserAgreement" xml:space="preserve">
+        <value>用户协议</value>
+    </data>
+    <data name="BackImageSetting_Description" xml:space="preserve">
+        <value>预览/设置 图片＆模糊度＆透明度</value>
+    </data>
+    <data name="BackImageSetting_Header" xml:space="preserve">
+        <value>背景图片设置</value>
+    </data>
+    <data name="BackImagePreview" xml:space="preserve">
+        <value>背景图片预览</value>
+    </data>
+    <data name="SelectBackgroundImage" xml:space="preserve">
+        <value>选择背景图片</value>
+    </data>
+    <data name="ClearBackgroundImage" xml:space="preserve">
+        <value>清空背景图片</value>
+    </data>
+    <data name="BackgroundImageBlurRadius_Description" xml:space="preserve">
+        <value>模糊效果过高容易导致卡顿</value>
+    </data>
+    <data name="BackgroundImageBlurRadius_Header" xml:space="preserve">
+        <value>图片模糊效果(实验性)</value>
+    </data>
+    <data name="BackgroundImageOpacity_Header" xml:space="preserve">
+        <value>图片不透明度(实验性)</value>
+    </data>
+    <data name="ProgramThemeSetting_Header" xml:space="preserve">
+        <value>程序主题设定</value>
+    </data>
+    <data name="ProgramThemeSetting_Description" xml:space="preserve">
+        <value>设定程序的主题风格为深/浅色模式</value>
+    </data>
+    <data name="ThemeModeSetting_Auto" xml:space="preserve">
+        <value>跟随系统</value>
+    </data>
+    <data name="ThemeModeSetting_Dark" xml:space="preserve">
+        <value>深色</value>
+    </data>
+    <data name="ThemeModeSetting_Light" xml:space="preserve">
+        <value>浅色</value>
+    </data>
+    <data name="LanguageSetting_Header" xml:space="preserve">
+        <value>语言设定</value>
+    </data>
+    <data name="LanguageSetting_Description" xml:space="preserve">
+        <value>设定程序显示的语言</value>
+    </data>
+    <data name="OpenWebsite" xml:space="preserve">
+        <value>打开网页</value>
+    </data>
+    <data name="HardwareMonitor_TextBlock" xml:space="preserve">
+        <value>传感器信息收集 ( 基于 LibreHardwareMonitor ) 信息仅供参考</value>
+    </data>
+    <data name="CollapseAll" xml:space="preserve">
+        <value>全部收起</value>
+    </data>
+    <data name="ExpandAll" xml:space="preserve">
+        <value>全部展开</value>
+    </data>
+    <data name="ErrorTitle" xml:space="preserve">
+        <value>错误</value>
+    </data>
+    <data name="HardwareMonitorInitError" xml:space="preserve">
+        <value>初始化硬件监控时出错:</value>
+    </data>
+    <data name="Welcome" xml:space="preserve">
+        <value>欢迎使用SYSTools工具箱</value>
+    </data>
+    <data name="News" xml:space="preserve">
+        <value>公告</value>
+    </data>
+    <data name="Hello" xml:space="preserve">
+        <value>您好：</value>
+    </data>
+    <data name="LoadingNews" xml:space="preserve">
+        <value>正在加载公告...</value>
+    </data>
+    <data name="NetError" xml:space="preserve">
+        <value>网络或网站出现问题</value>
+    </data>
+    <data name="NoticeInfo" xml:space="preserve">
+        <value>暂无公告</value>
+    </data>
+    <data name="NoticeError" xml:space="preserve">
+        <value>无法获取公告</value>
+    </data>
+    <data name="TimeUnitDay" xml:space="preserve">
+        <value>天</value>
+    </data>
+    <data name="TimeUnitHour" xml:space="preserve">
+        <value>时</value>
+    </data>
+    <data name="TimeUnitMinute" xml:space="preserve">
+        <value>分</value>
+    </data>
+    <data name="TimeUnitSecond" xml:space="preserve">
+        <value>秒</value>
+    </data>
+    <data name="SystemTime" xml:space="preserve">
+        <value>系统时间</value>
+    </data>
+    <data name="SystemStartTime" xml:space="preserve">
+        <value>启动日期</value>
+    </data>
+    <data name="SystemRunTime" xml:space="preserve">
+        <value>运行时间</value>
+    </data>
+    <data name="CurrentSystem" xml:space="preserve">
+        <value>系统版本</value>
+    </data>
+    <data name="UpdateHistory" xml:space="preserve">
+        <value>Windows 更新历史记录</value>
+    </data>
+    <data name="UpdateTitle" xml:space="preserve">
+        <value>更新标题</value>
+    </data>
+    <data name="UpdateDate" xml:space="preserve">
+        <value>日期</value>
+    </data>
+    <data name="UpdateStatus" xml:space="preserve">
+        <value>状态</value>
+    </data>
+    <data name="UpdateHistoryError" xml:space="preserve">
+        <value>加载更新历史记录失败</value>
+    </data>
+    <data name="UpdateStatusSuccess" xml:space="preserve">
+        <value>成功</value>
+    </data>
+    <data name="UpdateStatusFailed" xml:space="preserve">
+        <value>失败</value>
+    </data>
+    <data name="UpdateStatusUnknown" xml:space="preserve">
+        <value>未知</value>
+    </data>
+    <data name="LoadUpdateHistory" xml:space="preserve">
+        <value>加载更新历史</value>
+    </data>
+    <data name="ClearList" xml:space="preserve">
+        <value>清空列表</value>
+    </data>
+    <data name="ServiceProvider" xml:space="preserve">
+        <value>IPv4: ipip.net &amp; IPv6: neu6.edu</value>
+    </data>
+    <data name="IP" xml:space="preserve">
+        <value>公网IP</value>
+    </data>
+    <data name="LR_ToolTip" xml:space="preserve">
+        <value>左键单击获取 右键单击隐藏</value>
+    </data>
+    <data name="CustomTool_TextBlock" xml:space="preserve">
+        <value>自定义工具</value>
+    </data>
+    <data name="AddNewTool" xml:space="preserve">
+        <value>添加新工具</value>
+    </data>
+    <data name="AddCustomTool_TextBlock" xml:space="preserve">
+        <value>添加自定义工具</value>
+    </data>
+    <data name="OK" xml:space="preserve">
+        <value>确定</value>
+    </data>
+    <data name="Close" xml:space="preserve">
+        <value>取消</value>
+    </data>
+    <data name="Name" xml:space="preserve">
+        <value>名称:</value>
+    </data>
+    <data name="IconPath" xml:space="preserve">
+        <value>图标路径:</value>
+    </data>
+    <data name="EXEPath" xml:space="preserve">
+        <value>可执行文件:</value>
+    </data>
+    <data name="Args" xml:space="preserve">
+        <value>参数:</value>
+    </data>
+    <data name="CustomIcon" xml:space="preserve">
+        <value>自定义图标</value>
+    </data>
+    <data name="UseEXEEmbeddedIcon" xml:space="preserve">
+        <value>使用 exe 内嵌图标</value>
+    </data>
+    <data name="Browse" xml:space="preserve">
+        <value>浏览...</value>
+    </data>
+    <data name="Modify" xml:space="preserve">
+        <value>修改</value>
+    </data>
+    <data name="Delete" xml:space="preserve">
+        <value>删除</value>
+    </data>
+    <data name="SelectIcon" xml:space="preserve">
+        <value>选择图标</value>
+    </data>
+    <data name="SelectEXEFile" xml:space="preserve">
+        <value>选择可执行文件</value>
+    </data>
+    <data name="ImageFilter" xml:space="preserve">
+        <value>图像文件|*.png;*.jpg;*.ico|所有文件|*.*</value>
+    </data>
+    <data name="EXEFilter" xml:space="preserve">
+        <value>可执行文件|*.exe|所有文件|*.*</value>
+    </data>
+    <data name="Info" xml:space="preserve">
+        <value>提示</value>
+    </data>
+    <data name="NameAndExecutableRequired" xml:space="preserve">
+        <value>名称和可执行文件为必填项.</value>
+    </data>
+    <data name="Open" xml:space="preserve">
+        <value>启动</value>
+    </data>
+    <data name="ImageFilter_JPng" xml:space="preserve">
+        <value>图像文件 (*.jpg;*.png)|*.jpg;*.png</value>
+    </data>
+    <data name="ConfirmDeleteMessage" xml:space="preserve">
+        <value>确定要删除工具 '{0}' 吗？</value>
+    </data>
+    <data name="ConfirmModifyMessage" xml:space="preserve">
+        <value>是否要修改工具 '{0}' ？</value>
+    </data>
+    <data name="ConfirmDeleteTitle" xml:space="preserve">
+        <value>确认删除</value>
+    </data>
+    <data name="ConfirmModifyTitle" xml:space="preserve">
+        <value>确认修改</value>
+    </data>
+    <data name="AdministratorMode" xml:space="preserve">
+        <value>[管理员模式]</value>
+    </data>
+    <data name="ProcessTotal" xml:space="preserve">
+        <value>有一个同名进程正在运行！</value>
+    </data>
+    <data name="ProcessTotalTitle" xml:space="preserve">
+        <value>程序冲突！</value>
+    </data>
+    <data name="DetectionTools_Content" xml:space="preserve">
+        <value>检测工具</value>
+    </data>
+    <data name="TestTools_Content" xml:space="preserve">
+        <value>硬件测试工具</value>
+    </data>
+    <data name="DiskTools_Content" xml:space="preserve">
+        <value>硬盘工具</value>
+    </data>
+    <data name="PeripheralsTools_Content" xml:space="preserve">
+        <value>外设检测工具</value>
+    </data>
+    <data name="RepairingTools_Content" xml:space="preserve">
+        <value>运行库安装工具</value>
+    </data>
+    <data name="AIDA64_Text" xml:space="preserve">
+        <value>AIDA64提供了诸如协助超频，硬件侦错，压力测试和传感器监测等多种功能，而且还可以对处理器，系统内存和磁盘驱动器的性能进行全面评估。</value>
+    </data>
+    <data name="CPU-Z_Text" xml:space="preserve">
+        <value>CPU-Z提供一些关于处理器的信息，包含了制造厂及处理器名称，核心构造及封装技术，内部、外部频率，最大超频速度检测。</value>
+    </data>
+    <data name="GPU-Z_Text" xml:space="preserve">
+        <value>GPU-Z 是一个轻量级的系统实用程序，旨在提供有关您的显卡和图形处理器的重要信息。</value>
+    </data>
+    <data name="HWiNFO_Text" xml:space="preserve">
+        <value>HWiNFO 是一种用于硬件分析和监控的一体化解决方案，从快速概览展开到所有硬件组件的深度。始终保持最新状态，支持最新的技术和标准。</value>
+    </data>
+    <data name="HWMonitor_Text" xml:space="preserve">
+        <value>HWMonitor是一个硬件监控程序，它读取 PC 系统的主要健康传感器：电压、温度、风扇速度。</value>
+    </data>
+    <data name="Prime95_Text" xml:space="preserve">
+        <value>Prime95是一个专用测试系统稳定的软件。</value>
+    </data>
+    <data name="IntelBurnTest_Text" xml:space="preserve">
+        <value>IntelBurnTest是一款Intel/AMD处理器稳定性强力测试工具，简化了使用英特尔Linpack。</value>
+    </data>
+    <data name="FurMark_Text" xml:space="preserve">
+        <value>FurMark是oZone3D开发的一款OpenGL基准测试工具，通过皮毛渲染算法来衡量显卡的性能，同时还能借此考验显卡的稳定性。</value>
+    </data>
+    <data name="MemTest_Text" xml:space="preserve">
+        <value>TechPowerUp出品的MemTest内存稳定性测试工具。</value>
+    </data>
+    <data name="HKBTest_Text" xml:space="preserve">
+        <value>HKBTest是一款键盘测试工具，可以用于键盘按键冲突检测。</value>
+    </data>
+    <data name="MouseTest_Text" xml:space="preserve">
+        <value>MouseTest是鼠标之家出品的鼠标按键连点检测工具</value>
+    </data>
+    <data name="MouseRate_Text" xml:space="preserve">
+        <value>MouseRate是一款检测鼠标DPI和扫描率综合性能的软件</value>
+    </data>
+    <data name="AS-SSD_Text" xml:space="preserve">
+        <value>AS SSD Benchmark是一款功能强大、免费实用的硬盘性能测试工具,软件能够帮助用户测出固态硬盘持续读写等的性能。</value>
+    </data>
+    <data name="CrystalDiskInfo_Text" xml:space="preserve">
+        <value>CrystalDiskInfo是一个硬盘健康监测工具。它显示了硬盘驱动器的基本信息，智能监控和磁盘的温度。可以迅速读到本机硬盘的详细信息。</value>
+    </data>
+    <data name="CrystalDiskMark_Text" xml:space="preserve">
+        <value>CrystalDiskMark是一个衡量各种存储（HDD、SSD、USB 内存等）速度的基准软件。</value>
+    </data>
+    <data name="DiskBenchmark_Text" xml:space="preserve">
+        <value>ATTO Disk Benchmark 可以测量硬盘驱动器、固态驱动器、RAID 阵列以及主机连接到附加存储的性能。</value>
+    </data>
+    <data name="DiskGenius_Text" xml:space="preserve">
+        <value>DiskGenius是一款硬盘分区及数据维护软件。</value>
+    </data>
+    <data name="HDTune_Text" xml:space="preserve">
+        <value>HD Tune是一款具有多种功能的硬盘/SSD 实用程序。它可用于测量驱动器的性能、扫描错误、检查健康状态 (SMART)、安全擦除所有数据等等。</value>
+    </data>
+    <data name="LLFTOOL_Text" xml:space="preserve">
+        <value>LLFTOOL万能低格工具是一款适用于windows操作系统的硬盘低级格式化工具，该硬盘低格工具使用方便，操作简单。</value>
+    </data>
+    <data name="PartAssist_Text" xml:space="preserve">
+        <value>傲梅分区助手是一款免费、专业级的无损分区工具，提供简单、易用的磁盘分区管理操作。</value>
+    </data>
+    <data name="SSD-Z_Text" xml:space="preserve">
+        <value>SSD-Z是一款针对SSD设备的高可靠性的测试软件。</value>
+    </data>
+    <data name="Victoria_Text" xml:space="preserve">
+        <value>Victoria是Windows环境下强大的硬盘维护工具，具备硬盘表面检测/硬盘坏道修复/S.M.A.R.T.信息察看保存/Cache缓存控制等多功能的工具。</value>
+    </data>
+    <data name="H2TestW_Text" xml:space="preserve">
+        <value>H2testw是一款u盘读写速度测试和坏块检测软件，通过往待测目录写入数据的方式测试u盘的实际写入速度校验写入的数据是否正确。</value>
+    </data>
+    <data name="OpenFolder" xml:space="preserve">
+        <value>打开目录</value>
+    </data>
+    <data name="UncategorizedTools_Content" xml:space="preserve">
+        <value>未分类工具</value>
+    </data>
+    <data name="SDI_Text" xml:space="preserve">
+        <value>使用该工具可快速查找并安装所有丢失的驱动程序。</value>
+    </data>
+    <data name="Rufus_Text" xml:space="preserve">
+        <value>轻量级工具，用于从ISO文件创建可启动USB驱动器；支持多种操作系统镜像和高级分区方案。</value>
+    </data>
+    <data name="Etcher_Text" xml:space="preserve">
+        <value>跨平台工具，用于将操作系统镜像刷写到SD卡或USB驱动器，配备简单易用的用户界面。</value>
+    </data>
+    <data name="Ventoy_Text" xml:space="preserve">
+        <value>支持创建可启动的USB驱动器，该驱动器可存储并启动多个ISO/WIM/IMG/VHD(x)文件，且无需重新格式化。</value>
+    </data>
+    <data name="Version" xml:space="preserve">
+        <value>版本</value>
+    </data>
+    <data name="Memory" xml:space="preserve">
+        <value>内存</value>
+    </data>
+    <data name="Disk" xml:space="preserve">
+        <value>磁盘</value>
+    </data>
+    <data name="SystemResources" xml:space="preserve">
+        <value>系统资源</value>
+    </data>
+    <data name="SystemHealth" xml:space="preserve">
+        <value>系统健康</value>
+    </data>
+    <data name="SystemHealthGood" xml:space="preserve">
+        <value>良好</value>
+    </data>
+    <data name="SystemHealthWarning" xml:space="preserve">
+        <value>警告</value>
+    </data>
+    <data name="SystemHealthCritical" xml:space="preserve">
+        <value>严重</value>
+    </data>
+    <data name="QuickActions" xml:space="preserve">
+        <value>快速操作</value>
+    </data>
+    <data name="Weather" xml:space="preserve">
+        <value>天气</value>
+    </data>
+    <data name="LoadingWeather" xml:space="preserve">
+        <value>加载中...</value>
+    </data>
+    <data name="WeatherNotConfigured" xml:space="preserve">
+        <value>未配置天气服务</value>
+    </data>
+    <data name="Hitokoto" xml:space="preserve">
+        <value>一言</value>
+    </data>
+    <data name="LoadingHitokoto" xml:space="preserve">
+        <value>正在加载...</value>
+    </data>
+    <data name="Loading" xml:space="preserve">
+        <value>加载中...</value>
+    </data>
+    <data name="IPv4Error" xml:space="preserve">
+        <value>当前网络可能没有IPv4地址或获取失败</value>
+    </data>
+    <data name="IPv6Error" xml:space="preserve">
+        <value>当前网络可能没有IPv6地址或获取失败</value>
+    </data>
+    <data name="ConfirmAction" xml:space="preserve">
+        <value>确认执行此操作？</value>
+    </data>
+    <data name="Confirmation" xml:space="preserve">
+        <value>确认</value>
+    </data>
+    <data name="ExecutionError" xml:space="preserve">
+        <value>执行失败</value>
+    </data>
+    <data name="Error" xml:space="preserve">
+        <value>错误</value>
+    </data>
 </root>

--- a/SYSTools/SYSTools.csproj
+++ b/SYSTools/SYSTools.csproj
@@ -251,7 +251,7 @@
       <Version>0.10.2.1</Version>
     </PackageReference>
     <PackageReference Include="LibreHardwareMonitorLib">
-      <Version>0.9.4</Version>
+      <Version>0.9.5-pre548</Version>
     </PackageReference>
     <PackageReference Include="log4net">
       <Version>3.2.0</Version>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Revamps the Home page into a card-based, scrollable dashboard with resource monitoring, system health, quick actions, network/weather info, plus better localization change handling and minor UI/resource updates.
> 
> - **UI/UX (Home page)**:
>   - **Card-based dashboard** in `Pages/Home.xaml[.cs]` with scrollable layout and responsive column arrangement.
>   - Adds cards: `SystemTime`, `CurrentSystem`, `SystemResources` (CPU/Mem/Disk with animated bars), `SystemHealth`, `QuickActions`, `Public IP`, `Weather`, and `Hitokoto`.
>   - Announcement ticker refactor with timed fade-in transitions; page `Loaded/Unloaded` wiring; window min height increased to `700` in `MainWindow.xaml`.
> - **Logic & Infrastructure**:
>   - New timers for time/resource/notice updates; performance counters for CPU/Mem; disk usage via `DriveInfo`.
>   - Weather via `ip.sb` + `wttr.in`; public IP fetch with left/right-click behavior; quick actions execute system commands with confirmation.
>   - Handles dynamic relayout on resize; uses safe name registration; added async loading and error handling.
> - **Localization**:
>   - `LocalizationManager` now raises `PropertyChanged` with `nameof(CurrentCulture)` and empty string to refresh bindings; Home page subscribes to update UI/resources on culture change.
>   - Resource files (`Lang.en.resx`, `Lang.zh-Hans.resx`) expanded with keys for new cards/strings; designer `GeneratedCode` version updated.
> - **Other**:
>   - `Test.xaml.cs` refines display of screen resolution info into multi-line entries.
>   - `SYSTools.csproj`: bumps `LibreHardwareMonitorLib` to `0.9.5-pre548`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c7a0147a0e395f2a281dea810b0eb9b104d2552. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->